### PR TITLE
Add markdown and lint check to CI

### DIFF
--- a/.github/workflows/build-and-test.web.yml
+++ b/.github/workflows/build-and-test.web.yml
@@ -8,6 +8,10 @@
 
 name: Build and Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:
@@ -15,7 +19,22 @@ on:
   workflow_dispatch:
   workflow_call:
 
+defaults:
+  run:
+    working-directory: ./web
+
 jobs:
   reuseaction:
     name: REUSE Compliance Check
     uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
+  markdownlinkcheck:
+    name: Markdown Link Check
+    uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2
+  eslint:
+    name: ESLint
+    uses: ./.github/workflows/eslint.yml
+    permissions:
+      contents: read
+      checks: write
+    with:
+      working-directory: web

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,80 @@
+#
+# This source file is part of the Stanford Biodesign Digital Health Group open-source organization
+#
+# SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+# This is a copy of https://github.com/StanfordBDHG/.github/blob/main/.github/workflows/eslint.yml
+# which is currently not working with this repository because the working directory is not the
+# root directory. This is due to the fact that this repository is following a monorepo approach which
+# is more suitable for this project
+# This file will be further tested when a firebase backend is added and more side effects might be
+# uncovered from the changes. After it is working well for this repository a PR will be created in
+# https://github.com/StanfordBDHG/.github/tree/main/.github
+
+name: ESLint
+
+on:
+  workflow_call:
+    inputs:
+      nodeVersion:
+        description: 'Node version spec of the version to use in SemVer notation.'
+        required: false
+        type: string
+        default: '18'
+      working-directory:
+        description: 'Working directory eslint should be executed in'
+        required: false
+        type: string
+        default: '.'
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  eslint:
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.nodeVersion }}
+          cache: 'npm'
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+      - name: Install Node Dependencies
+        run: npm ci
+      - name: Save Code Linting Report JSON
+        run: npm run lint:ci
+        continue-on-error: true
+      - name: Check if PR is from a fork
+        id: fork-check
+        run: |
+          if [[ "${{ github.event_name }}" == 'pull_request' && "${{ github.event.pull_request.head.repo.fork }}" == 'true' ]]; then
+            echo "is_fork=true" >> $GITHUB_ENV
+          else
+            echo "is_fork=false" >> $GITHUB_ENV
+          fi
+      - name: Run ESLint if PR is from a fork
+        if: env.is_fork == 'true'
+        run: npm run lint:ci
+      - name: Annotate Code Linting Results
+        if: env.is_fork == 'false'
+        uses: ataylorme/eslint-annotate-action@v3
+        with:
+          only-pr-files: false
+          fail-on-warning: true
+          fail-on-error: true
+          markdown-report-on-step-summary: true
+      - name: Upload ESLint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eslint_report.json
+          path: ${{ inputs.working-directory }}/eslint_report.json

--- a/.github/workflows/monthly-markdown-link-check.yml
+++ b/.github/workflows/monthly-markdown-link-check.yml
@@ -1,0 +1,18 @@
+#
+# This source file is part of the Stanford Biodesign Digital Health RadGPT open-source project
+#
+# SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Monthly Markdown Link Check
+
+on:
+  schedule:
+    - cron: '0 8 1 * *'
+
+jobs:
+  markdown_link_check:
+    name: Markdown Link Check
+    uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:ci": "eslint --output-file eslint_report.json --format json .",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
Stacked PRs:
 * #10
 * #8
 * #7
 * __->__#6
 * #5
 * #4


--- --- ---

# Add markdown and lint check to CI

## :books: Documentation
* Add markdown check
* Add `eslint` check with code from the [`.github` repository](https://github.com/StanfordBDHG/.github/tree/main/.github) due to the missing `cache-dependency-path` parameter
* Add eslint.yml similar to https://github.com/StanfordBDHG/.github/blob/v2/.github/workflows/eslint.yml as the standard file does not work with the given monorepo approach. The workflow will be refined as also a backend gets added. After it has been tested thoroughly in this project, a PR will be created in https://github.com/StanfordBDHG/.github


## :white_check_mark: Testing
See CI


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).