### PR TITLE
Change emulated env variable to optional

### DIFF
--- a/web/env.ts
+++ b/web/env.ts
@@ -17,7 +17,11 @@ export const env = createEnv({
     VITE_PUBLIC_FIREBASE_STORAGE_BUCKET: z.string().min(1),
     VITE_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: z.string().min(1),
     VITE_PUBLIC_FIREBASE_APP_ID: z.string().min(1),
-    VITE_PUBLIC_FIREBASE_EMULATED: z.string().transform((s) => s === "true"),
+    VITE_PUBLIC_FIREBASE_EMULATED: z
+      .string()
+      .transform((s) => s === "true")
+      .optional()
+      .default("false"),
   },
   clientPrefix: "VITE_PUBLIC",
   runtimeEnv: {


### PR DESCRIPTION
Stacked PRs:
 * #17
 * #13
 * #15
 * __->__#14


--- --- ---

# Change emulated env variable to optional


## ♻️ Current situation & Problem

Since the `VITE_PUBLIC_FIREBASE_EMULATED` environment variable is not optional, the current hosting deployment of web is not working properly (see image below)
![image](https://github.com/user-attachments/assets/20bf754b-4709-49fd-908a-252f085b9914)

## ✅ Testing

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/25480cff-1c4b-4021-aa9a-251fb1e4852a)|![image](https://github.com/user-attachments/assets/385a9502-57e5-46c0-87b5-5d6e9b125eff)


## Code of Conduct & Contributing Guidelines
By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md): 

- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).