### PR TITLE
Add Storage Trigger with Radgraph Annotations

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -7,6 +7,7 @@
     {
       "source": "functions",
       "codebase": "default",
+      "runtime": "python310",
       "ignore": [
         "venv",
         ".git",

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -9,8 +9,12 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if false;
+    function isAuthenticatedUserID(userId) {
+      return request.auth != null && request.auth.uid == userId;
+    }
+    
+    match /users/{userId}/annotations/{reportHash} {
+      allow read: if isAuthenticatedUserID(userId);
     }
   }
 }

--- a/firebase/functions/main.py
+++ b/firebase/functions/main.py
@@ -6,13 +6,16 @@
 # SPDX-License-Identifier: MIT
 #
 
+import json
 import pathlib
-from firebase_functions import https_fn
-from firebase_admin import initialize_app
-from firebase_functions import storage_fn
+import re
 
+from firebase_functions import https_fn, storage_fn
+from firebase_admin import initialize_app, storage, firestore
+from radgraph import RadGraph, get_radgraph_processed_annotations
 
 initialize_app()
+db = firestore.client()
 
 
 @https_fn.on_request()
@@ -24,7 +27,34 @@ def on_request_example(_req: https_fn.Request) -> https_fn.Response:
 def on_medical_report_upload(
     event: storage_fn.CloudEvent[storage_fn.StorageObjectData],
 ):
-    bucket_name = event.data.bucket
     file_path = pathlib.PurePath(event.data.name)
-    content_type = event.data.content_type
-    print(bucket_name, file_path, content_type)
+
+    # Forcing the pattern "users/{userid}/reports/{filename}" and also extracting userid and filename
+    # Hence, it is ensured that this function gets executerd only on files in "users/{userid}/reports"
+    match = re.match(
+        r"^users/(?P<uid>[^/]*)/reports/(?P<file_name>[^/]*)$", str(file_path)
+    )
+    if match is None:
+        return
+    uid = match.group("uid")
+    file_name = match.group("file_name")
+
+    # based on https://firebase.google.com/docs/storage/extend-with-functions?gen=2nd
+    bucket_name = event.data.bucket
+    bucket = storage.bucket(bucket_name)
+    file_blob = bucket.blob(str(file_path))
+    file_str = file_blob.download_as_text()
+
+    radgraph = RadGraph(model_type="radgraph-xl")
+    annotations = radgraph([file_str])
+    processed_annotations = get_radgraph_processed_annotations(annotations)
+
+    ref = db.collection(f"users/{uid}/annotations").document(file_name)
+    ref.set(
+        {
+            "radgraph_text": processed_annotations["radgraph_text"],
+            "processed_annotations": json.dumps(
+                processed_annotations["processed_annotations"]
+            ),
+        }
+    )

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -10,15 +10,14 @@ rules_version = '2';
 
 service firebase.storage {
   match /b/{bucket}/o {
-    match /users/{userId}/reports/{allPaths=**} {
-      allow read: if request.auth != null && request.auth.uid == userId;
-      allow create: if request.auth != null && request.auth.uid == userId
+    function isAuthenticatedUserID(userId) {
+      return request.auth != null && request.auth.uid == userId;
+    }
+
+    match /users/{userId}/reports/{reportHash} {
+      allow read: if isAuthenticatedUserID(userId);
+      allow create: if isAuthenticatedUserID(userId)
                     && request.resource.contentType.matches("text/plain");
     } 
-
-    // restrict all others
-    match /{allPaths=**} {
-      allow read, write: if false;
-    }
   }
 }

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -18,83 +18,83 @@
 
 // Import Routes
 
-import { Route as rootRoute } from './routes/__root'
-import { Route as ProtectedpageImport } from './routes/protected_page'
-import { Route as IndexImport } from './routes/index'
+import { Route as rootRoute } from "./routes/__root";
+import { Route as ProtectedpageImport } from "./routes/protected_page";
+import { Route as IndexImport } from "./routes/index";
 
 // Create/Update Routes
 
 const ProtectedpageRoute = ProtectedpageImport.update({
-  path: '/protected_page',
+  path: "/protected_page",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const IndexRoute = IndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 // Populate the FileRoutesByPath interface
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/protected_page': {
-      id: '/protected_page'
-      path: '/protected_page'
-      fullPath: '/protected_page'
-      preLoaderRoute: typeof ProtectedpageImport
-      parentRoute: typeof rootRoute
-    }
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/protected_page": {
+      id: "/protected_page";
+      path: "/protected_page";
+      fullPath: "/protected_page";
+      preLoaderRoute: typeof ProtectedpageImport;
+      parentRoute: typeof rootRoute;
+    };
   }
 }
 
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/protected_page': typeof ProtectedpageRoute
+  "/": typeof IndexRoute;
+  "/protected_page": typeof ProtectedpageRoute;
 }
 
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/protected_page': typeof ProtectedpageRoute
+  "/": typeof IndexRoute;
+  "/protected_page": typeof ProtectedpageRoute;
 }
 
 export interface FileRoutesById {
-  __root__: typeof rootRoute
-  '/': typeof IndexRoute
-  '/protected_page': typeof ProtectedpageRoute
+  __root__: typeof rootRoute;
+  "/": typeof IndexRoute;
+  "/protected_page": typeof ProtectedpageRoute;
 }
 
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/protected_page'
-  fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/protected_page'
-  id: '__root__' | '/' | '/protected_page'
-  fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath;
+  fullPaths: "/" | "/protected_page";
+  fileRoutesByTo: FileRoutesByTo;
+  to: "/" | "/protected_page";
+  id: "__root__" | "/" | "/protected_page";
+  fileRoutesById: FileRoutesById;
 }
 
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  ProtectedpageRoute: typeof ProtectedpageRoute
+  IndexRoute: typeof IndexRoute;
+  ProtectedpageRoute: typeof ProtectedpageRoute;
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ProtectedpageRoute: ProtectedpageRoute,
-}
+};
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
 /* prettier-ignore-end */
 

--- a/web/src/routes/protected_page.tsx
+++ b/web/src/routes/protected_page.tsx
@@ -17,7 +17,9 @@ import { Textarea } from "@stanfordspezi/spezi-web-design-system/components/Text
 import { Button } from "@stanfordspezi/spezi-web-design-system/components/Button";
 
 const formSchema = z.object({
-  medicalReportContent: z.string().min(1, "Content of medical report is required"),
+  medicalReportContent: z
+    .string()
+    .min(1, "Content of medical report is required"),
   medicalReportName: z.string().min(1, "Name of medical report is required"),
 });
 
@@ -30,7 +32,7 @@ const calculateSHA256Hash = async (data: string) => {
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
   return hashHex;
-}
+};
 
 const ProtectedComponent = () => {
   const currentUser = useAuthenticatedUser();
@@ -38,15 +40,21 @@ const ProtectedComponent = () => {
     formSchema,
   });
 
-  const handleSubmit = form.handleSubmit(async ({ medicalReportContent, medicalReportName }) => {
-    const medicalReportContentHash = await calculateSHA256Hash(medicalReportContent)
-    const storageReference = ref(
-      storage,
-      `users/${currentUser?.uid}/reports/${medicalReportContentHash}`,
-    );
-    const custmoMetadata = { medicalReportName: medicalReportName }
-    await uploadString(storageReference, medicalReportContent, "raw", { contentType: 'text/plain', customMetadata: custmoMetadata })
-  });
+  const handleSubmit = form.handleSubmit(
+    async ({ medicalReportContent, medicalReportName }) => {
+      const medicalReportContentHash =
+        await calculateSHA256Hash(medicalReportContent);
+      const storageReference = ref(
+        storage,
+        `users/${currentUser?.uid}/reports/${medicalReportContentHash}`,
+      );
+      const custmoMetadata = { medicalReportName: medicalReportName };
+      await uploadString(storageReference, medicalReportContent, "raw", {
+        contentType: "text/plain",
+        customMetadata: custmoMetadata,
+      });
+    },
+  );
 
   return (
     <>

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -8,6 +8,9 @@
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./src/**/*.{ts,tsx}", "./node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js"],
+  content: [
+    "./src/**/*.{ts,tsx}",
+    "./node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js",
+  ],
   plugins: [],
 };


### PR DESCRIPTION
Stacked PRs:
 * #22
 * #21
 * __->__#19


--- --- ---

# Add Storage Trigger with Radgraph Annotations

## :recycle: Current situation & Problem
When a new medical report gets uploaded by a user, a Radgraph annotation should be created.

## :books: Documentation
* Files in `users/{userid}/reports/` trigger Radgraph Annotations (secured by [regex](https://github.com/StanfordBDHG/RadGPT/pull/19/files#diff-41451d84f94160aae97f037a67c01cd015853547904d2c98bcdfd18d89e121f9R36))
* Annotations get created in `users/{userid}/annotations/`
* The annotations have the name as the file that triggered it with `.json` added to the end (i.e. "Medical Report" --> "Medical Report.json")


## :white_check_mark: Testing

`firebase emulators:start --project demo-radgpt`

![image](https://github.com/user-attachments/assets/34973dd6-f8f9-4288-83b2-43a16cbc391f)
![image](https://github.com/user-attachments/assets/dab83f64-3e94-4e5c-b309-d965acf5c78f)
![image](https://github.com/user-attachments/assets/be06f91b-c085-4cf7-b6d8-e7e3ecc4c65f)



### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).