### PR TITLE
Change Name of GH Actions to Avoid Duplicates

### DIFF
--- a/.github/workflows/build-and-test.firebase.yml
+++ b/.github/workflows/build-and-test.firebase.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Build and Test
+name: Build and Test Firebase
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-and-test.web.yml
+++ b/.github/workflows/build-and-test.web.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Build and Test
+name: Build and Test Web
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deployment.firebase.yml
+++ b/.github/workflows/deployment.firebase.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Deployment
+name: Deployment Firebase
 
 on:
   push:

--- a/.github/workflows/deployment.web.yml
+++ b/.github/workflows/deployment.web.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Deployment
+name: Deployment Web
 
 on:
   push:

--- a/.github/workflows/production.web.yml
+++ b/.github/workflows/production.web.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Production Deployment
+name: Production Deployment Web
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Stacked PRs:
 * #19
 * #18
 * #13
 * __->__#20


--- --- ---

# Change Name of GH Actions to Avoid Duplicates

## :recycle: Current situation & Problem
Since the names of Github Actions are the same (e.g. "Build and Test") they can collide and, hence, cancel each other. Therefore, Github Actions are not getting executed when there are changes to "web/" and "firebase/".


## :white_check_mark: Testing

https://github.com/StanfordBDHG/RadGPT/pull/19/checks

![image](https://github.com/user-attachments/assets/456f4ba2-b097-4519-8b2f-6d6922d31c1a)

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).