### PR TITLE
Fix Python Version in Github CD

### DIFF
--- a/.github/workflows/deployment.firebase.yml
+++ b/.github/workflows/deployment.firebase.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.10
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -97,9 +97,9 @@ jobs:
       - name: Setup Python Virutal Environment
         working-directory: firebase
         run: |
-          python3.12 -m venv functions/venv
+          python3.10 -m venv functions/venv
           . functions/venv/bin/activate
-          python3.12 -m pip install -r functions/requirements.txt
+          python3.10 -m pip install -r functions/requirements.txt
       - name: Deploy to Firebase
         working-directory: firebase
         run: |


### PR DESCRIPTION
Stacked PRs:
 * #22
 * #21
 * __->__#23


--- --- ---

# Fix Python Version in Github CD

## :recycle: Current situation & Problem
The Github CD is failing due to a Python version change in #19. This can be resolved by adjusting the Python versions of the CD file.

## :gear: Release Notes 
* Adjusted Python version in Github Action workflow that deploys Firebase functions

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).