### PR TITLE
Add GPT Cache

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -13,7 +13,7 @@ service cloud.firestore {
       return request.auth != null && request.auth.uid == userId;
     }
     
-    match /users/{userId}/annotations/{reportHash} {
+    match /users/{userId}/annotations/{documentName} {
       allow read: if isAuthenticatedUserID(userId);
     }
   }


### PR DESCRIPTION
Stacked PRs:
 * __->__#34


--- --- ---

# Add GPT Cache

## :recycle: Current situation & Problem
We don't want to send requests for the same observations to ChatGPT. Hence, we are adding a cache layer to Firebase which can also be used for feedback storage later on.

## :white_check_mark: Testing

https://github.com/user-attachments/assets/b5218cc2-ad30-45b1-83a7-b6c26f393eb3


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


https://github.com/user-attachments/assets/b8cb2e9d-bb9b-48dc-9639-2b39e8851074
![image](https://github.com/user-attachments/assets/1a59e423-3435-461c-a7ec-2fc9c5300173)