### PR TITLE
Add Cloud Storage Rules Tests

### DIFF
--- a/firebase/firebase_rule_tests/storage.test.ts
+++ b/firebase/firebase_rule_tests/storage.test.ts
@@ -1,0 +1,84 @@
+
+//
+// This source file is part of the Stanford Biodesign Digital Health RadGPT open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { beforeAll, beforeEach, describe, test } from 'vitest'
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment
+} from '@firebase/rules-unit-testing'
+import {
+    deleteObject,
+    getBytes,
+    listAll,
+    ref,
+    uploadString,
+} from "firebase/storage";
+
+const PROJECT_ID = "demo-radgpt"
+
+const db = await initializeTestEnvironment({ projectId: PROJECT_ID })
+
+describe("Unauthenticated", () => {
+    let testRef;
+    beforeAll(async () => {
+        const unauthenticatedDb = db.unauthenticatedContext().storage();
+        testRef = ref(unauthenticatedDb, "/users/user1/reports/document")
+    })
+    test("Blocking Read/List Access", async () => {
+        await assertFails(getBytes(testRef))
+    })
+    test("Blocking Write Access", async () => {
+        await assertFails(uploadString(testRef, ""))
+    })
+})
+
+describe("Authenticated Processed Annotations Access", () => {
+    let user1;
+    let user2;
+    beforeAll(async () => {
+        user1 = db.authenticatedContext("user1").storage();
+        user2 = db.authenticatedContext("user2").storage();
+        await uploadString(ref(user1, "/users/user1/reports/document"), "test", "raw", {
+            contentType: "text/plain",
+        })
+
+        return async () => {
+            await db.withSecurityRulesDisabled(async (context) => {
+                await deleteObject(ref(context.storage(), "/users/user1/reports/document"))
+            })
+        }
+    })
+    test("Test Allowed User1 Read Access", async () => {
+        const documentRef = ref(user1, "/users/user1/reports/document")
+        const folderRef = ref(user1, "/users/user1/reports")
+        await assertSucceeds(getBytes(documentRef))
+        await assertSucceeds(listAll(folderRef))
+    })
+    test("Test Blocked User2 Read Access", async () => {
+        const documentRef = ref(user2, "/users/user1/reports/document")
+        const folderRef = ref(user2, "/users/user1/reports")
+        await assertFails(getBytes(documentRef))
+        await assertFails(listAll(folderRef))
+    })
+    test("Test Blocked File Deletion", async () => {
+        await assertFails(deleteObject(ref(user1, "/users/user1/reports/document")))
+        await assertFails(deleteObject(ref(user2, "/users/user1/reports/document")))
+    })
+    test("Test Allowed File Upload User 1", async() => {
+        await assertSucceeds(uploadString(ref(user1, "/users/user1/reports/document1"), "test1", "raw", {
+            contentType: "text/plain",
+        }))
+    })
+    test("Test Allowed File Upload User 2", async() => {
+        await assertFails(uploadString(ref(user2, "/users/user1/reports/document2"), "test1", "raw", {
+            contentType: "text/plain",
+        }))
+    })
+})

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "main": "test.ts",
   "scripts": {
-    "emulator:test": "firebase emulators:exec --only firestore \"npm run test run\" --project demo-radgpt",
-    "emulator:report-dev": "firebase emulators:exec --only firestore \"npm run test run && curl http://localhost:8080/emulator/v1/projects/demo-radgpt:ruleCoverage.html > coverage.html && curl http://localhost:8080/emulator/v1/projects/demo-radgpt:ruleCoverage > coverage.json\" --project demo-radgpt",
-    "emulator:test-dev": "firebase emulators:exec --only firestore \"npm run test\" --project demo-radgpt",
+    "emulator:test": "firebase emulators:exec --only firestore,storage \"npm run test run\" --project demo-radgpt",
+    "emulator:report-dev": "firebase emulators:exec --only firestore,storage \"npm run test run && curl http://localhost:8080/emulator/v1/projects/demo-radgpt:ruleCoverage.html > coverage.html && curl http://localhost:8080/emulator/v1/projects/demo-radgpt:ruleCoverage > coverage.json\" --project demo-radgpt",
+    "emulator:test-dev": "firebase emulators:exec --only firestore,storage \"npm run test\" --project demo-radgpt",
     "test": "vitest"
   },
   "author": "",


### PR DESCRIPTION
Stacked PRs:
 * #39
 * __->__#38


--- --- ---

# *Add Cloud Storage Rules Tests*

## :recycle: Current situation & Problem
In order to ensure that the Firebase Cloud Storage is only accessed by authorized users, tests are introduced.

## :gear: Release Notes 
* Add Cloud Storage Rules Tests

## :white_check_mark: Testing
```
firebase $> firebase emulators:exec --only firestore,storage \"npm run test run\" --project demo-radgpt
...
 ✓ firebase_rule_tests/firestore.test.ts (11) 3858ms
 ✓ firebase_rule_tests/storage.test.ts (7) 484ms

 Test Files  2 passed (2)
      Tests  18 passed (18)
   Start at  15:22:12
   Duration  5.34s (transform 126ms, setup 0ms, collect 887ms, tests 4.34s, environment 0ms, prepare 150ms)

✔  Script exited successfully (code 0)
```

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).