### PR TITLE
Block Duplicate Medical Report Upload

### DIFF
--- a/firebase/firebase_rule_tests/storage.test.ts
+++ b/firebase/firebase_rule_tests/storage.test.ts
@@ -72,6 +72,11 @@ describe("Authenticated Processed Annotations Access", () => {
             contentType: "text/plain",
         }))
     })
+    test("Test Blocked Overwrite through File Upload User 1", async() => {
+        await assertFails(uploadString(ref(user1, "/users/user1/reports/document"), "test1", "raw", {
+            contentType: "text/plain",
+        }))
+    })
     test("Test Allowed File Upload User 2", async() => {
         await assertFails(uploadString(ref(user2, "/users/user1/reports/document2"), "test1", "raw", {
             contentType: "text/plain",

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -17,7 +17,8 @@ service firebase.storage {
     match /users/{userId}/reports/{reportHash} {
       allow read: if isAuthenticatedUserID(userId);
       allow create: if isAuthenticatedUserID(userId)
-                    && request.resource.contentType.matches("text/plain");
+                    && request.resource.contentType.matches("text/plain")
+                    && resource == null;
       allow delete: if isAuthenticatedUserID(userId);
     } 
   }

--- a/web/e2e-tests/tests/uploadDuplicateMedicalReportFlow.spec.ts
+++ b/web/e2e-tests/tests/uploadDuplicateMedicalReportFlow.spec.ts
@@ -1,0 +1,69 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health RadGPT open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { test, expect } from "@playwright/test";
+
+test("Test Duplicate Medical Report Upload", async ({ page }) => {
+  await page.goto("./signin?redirect=%2F");
+  const page1Promise = page.waitForEvent("popup");
+  await page.getByRole("button", { name: "Sign in with Google" }).click();
+  const page1 = await page1Promise;
+  await page1.getByRole("button", { name: "Add new account" }).click();
+  await page1
+    .getByRole("button", { name: "Auto-generate user information" })
+    .click();
+  await page1.getByRole("button", { name: "Sign in with Google.com" }).click();
+  await page.getByRole("button").first().click();
+  await page.getByLabel("Name").fill("CT Abdomen");
+  await page.getByLabel("Name").press("Tab");
+  await page
+    .getByLabel("Medical Report Content")
+    .fill(
+      "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract"
+    );
+  await page.getByRole("button", { name: "Submit" }).click();
+  await page.getByRole("button").first().click();
+  await page
+    .getByLabel("Medical Report Content")
+    .fill(
+      "Hypodense lesion is observed in the right hepatic lobe, measuring 2.5 cm and appearing non-enhancing on contrast-enhanced imaging, suggestive of a benign cyst."
+    );
+  await page.getByLabel("Name").click();
+  await page.getByLabel("Name").fill("Hypodense Lesion");
+  await page.getByRole("button", { name: "Submit" }).click();
+  await page.getByRole("button").first().click();
+  await page.getByLabel("Name").fill("CT Abdomen 1");
+  await page.getByLabel("Name").press("Tab");
+  await page
+    .getByLabel("Medical Report Content")
+    .fill(
+      "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract"
+    );
+  await expect(page.getByText("Hypodense", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Submit" }).click();
+  await expect(page.getByText("This medical report has")).toBeVisible();
+  await expect(
+    page.getByText(
+      "This medical report has already been uploaded. It has now been selected."
+    )
+  ).toBeVisible();
+  await expect(page.locator("#root")).toContainText(
+    "Study Type: CT Abdomen and Pelvis Indication: Evaluation for kidney stones due to symptoms of flank pain and hematuria. Findings: The kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter. In the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall. Impression: Small non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary. No other abnormalities detected in the kidneys or urinary tract"
+  );
+  await expect(
+    page
+      .getByRole("complementary")
+      .getByText("CT AbdomenHypodense LesionSign out")
+  ).toMatchAriaSnapshot(`
+      - text: CT Abdomen
+      - img
+      - text: Hypodense Lesion
+      - img
+      - button "Sign out"
+      `);
+});

--- a/web/src/routes/~_dashboard/AddFileButton.tsx
+++ b/web/src/routes/~_dashboard/AddFileButton.tsx
@@ -18,13 +18,38 @@ import { useOpenState } from "@stanfordspezi/spezi-web-design-system/utils/useOp
 import { type StorageReference } from "firebase/storage";
 import { FilePlus } from "lucide-react";
 import { FileCreationForm } from "./FileCreationForm";
+import { toast } from "@stanfordspezi/spezi-web-design-system";
+import { GetFileListResult } from "@/utils/queries";
 
 interface AddFileModalProps {
   onUploadSuccess?: (ref: StorageReference, medicalReport: string) => void;
+  files: GetFileListResult;
+  setSelectedFile: React.Dispatch<
+    React.SetStateAction<StorageReference |undefined>
+  >;
 }
 
-export function AddFileButton({ onUploadSuccess }: AddFileModalProps) {
+export function AddFileButton({
+  onUploadSuccess,
+  files,
+  setSelectedFile,
+}: AddFileModalProps) {
   const openState = useOpenState(false);
+
+  const onUploadSuccessDialogClose = (
+    ref: StorageReference,
+    medicalReport: string
+  ) => {
+    if (onUploadSuccess) onUploadSuccess(ref, medicalReport);
+    openState.close();
+  };
+  const onExistingFileUploadDialogClose = (ref: StorageReference) => {
+    setSelectedFile(ref);
+    toast.info(
+      "This medical report has already been uploaded. It has now been selected."
+    );
+    openState.close();
+  };
 
   return (
     <Dialog open={openState.isOpen} onOpenChange={openState.setIsOpen}>
@@ -38,11 +63,10 @@ export function AddFileButton({ onUploadSuccess }: AddFileModalProps) {
           <DialogTitle>Add New Medical Report</DialogTitle>
         </DialogHeader>
         <FileCreationForm
-          onUploadSuccess={(ref, medicalReport) => {
-            if (onUploadSuccess) onUploadSuccess(ref, medicalReport);
-            openState.close();
-          }}
-        />
+          onUploadSuccess={onUploadSuccessDialogClose}
+          files={files}
+          onExistingFileUpload={onExistingFileUploadDialogClose}
+        ></FileCreationForm>
       </DialogContent>
     </Dialog>
   );

--- a/web/src/routes/~_dashboard/DashboardLayout.tsx
+++ b/web/src/routes/~_dashboard/DashboardLayout.tsx
@@ -54,12 +54,11 @@ export const DashboardLayout = ({
       <nav
         className={cn(
           "fixed left-0 right-0 top-[calc(var(--headerHeight)+1px)] flex h-[calc(100vh-var(--headerHeight)-1px)] w-screen flex-col overflow-y-auto bg-surface transition duration-300 lg:hidden",
-          menu.isOpen ? "z-10 translate-x-0" : (
-            "pointer-events-none -translate-x-24 opacity-0"
-          ),
+          menu.isOpen
+            ? "z-10 translate-x-0"
+            : "pointer-events-none -translate-x-24 opacity-0"
         )}
         hidden={!menu.isOpen}
-        data-testid="mobileMenu"
       >
         {actions && <div className="p-4">{actions}</div>}
         {mobile}

--- a/web/src/routes/~_dashboard/SideMenu.tsx
+++ b/web/src/routes/~_dashboard/SideMenu.tsx
@@ -13,6 +13,7 @@ import { type StorageReference } from "firebase/storage";
 import { type Dispatch, type SetStateAction } from "react";
 import { type GetFileListResult } from "@/utils/queries";
 import { FileList } from "./FileList";
+import {AddFileButton} from "./AddFileButton";
 
 interface SideMenuProps {
   auth: Auth;
@@ -21,6 +22,7 @@ interface SideMenuProps {
   setSelectedFile: Dispatch<SetStateAction<StorageReference | undefined>>;
   className?: string;
   onFileDelete: () => Promise<void>;
+  onUploadSuccess?: (ref: StorageReference, medicalReport: string) => void;
 }
 
 export function SideMenu({
@@ -30,18 +32,31 @@ export function SideMenu({
   setSelectedFile,
   className,
   onFileDelete,
+  onUploadSuccess,
 }: SideMenuProps) {
   return (
-    <div className={cn("flex h-full w-full flex-col items-start", className)}>
-      <FileList
+    <div className="flex flex-col items-start justify-begin w-full h-full px-2 xl:px-0 lg:mt-0 mt-3">
+      <AddFileButton
+        onUploadSuccess={onUploadSuccess}
         files={files}
-        selectedFile={selectedFile}
         setSelectedFile={setSelectedFile}
-        onFileDelete={onFileDelete}
       />
-      <Button className="mt-auto" onClick={() => auth.signOut()}>
-        Sign out
-      </Button>
+      <div
+        className={cn(
+          "flex flex-col items-start w-full h-full mt-4",
+          className
+        )}
+      >
+        <FileList
+          files={files}
+          selectedFile={selectedFile}
+          setSelectedFile={setSelectedFile}
+          onFileDelete={onFileDelete}
+        />
+        <Button className="mt-auto" onClick={() => auth.signOut()}>
+          Sign out
+        </Button>
+      </div>
     </div>
   );
 }

--- a/web/src/routes/~_dashboard/~index.tsx
+++ b/web/src/routes/~_dashboard/~index.tsx
@@ -13,16 +13,15 @@ import { useCallback, useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useAuthenticatedUser } from "@/hooks/useAuthenticatedUser";
 import { auth, firestore } from "@/utils/firebase";
+import {ReportText} from "./ReportText";
 import {
   getProcessedAnnotationsFromJSONString,
   type ProcessedAnnotations,
 } from "@/utils/processedAnnotations";
 import { type GetFileListResult, getFileList } from "@/utils/queries";
 import { type TextMapping } from "@/utils/textMapping";
-import { AddFileButton } from "./AddFileButton";
 import { DashboardLayout } from "./DashboardLayout";
 import { FeedbackForm } from "./FeedbackForm";
-import { ReportText } from "./ReportText";
 import { SideMenu } from "./SideMenu";
 
 function Dashboard() {
@@ -55,14 +54,14 @@ function Dashboard() {
     let ignore = false;
     const annotationReference = doc(
       firestore,
-      `users/${currentUser?.uid}/${selectedFile.name}/report_meta_data`,
+      `users/${currentUser?.uid}/${selectedFile.name}/report_meta_data`
     );
     const unsubscribe = onSnapshot(annotationReference, (documentSnapshot) => {
       if (ignore) {
         return;
       }
       const data = getProcessedAnnotationsFromJSONString(
-        documentSnapshot.data(),
+        documentSnapshot.data()
       );
       if (!data) {
         setTextMapping(null);
@@ -102,20 +101,17 @@ function Dashboard() {
         <title>RadGPT</title>
       </Helmet>
       <DashboardLayout
-        title={<AddFileButton onUploadSuccess={onUploadSuccess} />}
         mobile={
           <SideMenu
-            className="px-2 pt-4"
             auth={auth}
             files={files}
             selectedFile={selectedFile}
             setSelectedFile={setSelectedFile}
             onFileDelete={onFileDelete}
+            onUploadSuccess={onUploadSuccess}
           />
         }
         aside={
-          <div className="justify-begin flex h-full w-full flex-col items-start px-2 xl:px-0">
-            <AddFileButton onUploadSuccess={onUploadSuccess} />
             <SideMenu
               className="mt-4"
               auth={auth}
@@ -123,8 +119,8 @@ function Dashboard() {
               selectedFile={selectedFile}
               setSelectedFile={setSelectedFile}
               onFileDelete={onFileDelete}
+            onUploadSuccess={onUploadSuccess}
             />
-          </div>
         }
       >
         {reportText ?

--- a/web/src/utils/queries.ts
+++ b/web/src/utils/queries.ts
@@ -11,22 +11,22 @@ import { type FullMetadata, getMetadata, listAll, ref } from "firebase/storage";
 import { storage } from "./firebase";
 
 const metaDataCompare = (metaData1: FullMetadata, metaData2: FullMetadata) => {
-  const dateFile1 = new Date(metaData1.updated);
-  const dateFile2 = new Date(metaData2.updated);
+  const dateFile1 = new Date(metaData1.timeCreated);
+  const dateFile2 = new Date(metaData2.timeCreated);
 
-  if (dateFile1 < dateFile2) return 1;
-  if (dateFile1 > dateFile1) return -1;
+  if (dateFile1 > dateFile2) return 1;
+  if (dateFile1 < dateFile2) return -1;
   return 0;
 };
 
 export async function getFileList(currentUser: User) {
   const storageReportsReference = ref(
     storage,
-    `users/${currentUser.uid}/reports`,
+    `users/${currentUser.uid}/reports`
   );
   const listResult = await listAll(storageReportsReference);
   const fileMetadata = await Promise.all(
-    listResult.items.map((i) => getMetadata(i)),
+    listResult.items.map((i) => getMetadata(i))
   );
   const fileList = fileMetadata.sort(metaDataCompare).map((fullMetaData) => ({
     ref: fullMetaData.ref,


### PR DESCRIPTION
Stacked PRs:
 * __->__#59


--- --- ---

# Block Duplicate Medical Report Upload

## :recycle: Current situation & Problem
Currently, the is name used in the database is specified by the hash of the content of the medical report. When exactly the same report is uploaded multiple times, the whole RadGraph inference will be rerun leading to additional effort and cost.


## :books: Documentation
* Add Security Rule to not allow upload of duplicate reports
* Add Security Rule testing
* Add frontend logic to handle duplicate report upload by showing a toaster and selecting the medical report
* Add e2e test


## :white_check_mark: Testing

https://github.com/user-attachments/assets/70fdc058-a222-438c-994b-f5bf6b6c74a0

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).