### PR TITLE
Add Firebase Storage Deletion Function to Firebase Deploy Workflow

### DIFF
--- a/.github/workflows/deployment.firebase.yml
+++ b/.github/workflows/deployment.firebase.yml
@@ -113,7 +113,7 @@ jobs:
           echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 -d > "$RUNNER_TEMP/google-application-credentials.json"
           export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
           echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
-          firebase deploy --project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID }} --only firestore,storage,functions:on_medical_report_upload,functions:on_detailed_explanation_request
+          firebase deploy --project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID }} --only firestore,storage,functions:on_report_meta_data_delete,functions:on_medical_report_upload,functions:on_detailed_explanation_request
       - name: Clean up Google application credentials
         if: always()
         run: |


### PR DESCRIPTION
Stacked PRs:
 * __->__#65


--- --- ---

# Add Firebase Storage Deletion Function to Firebase Deploy Workflow

## :recycle: Current situation & Problem
The last push has not deployed the Firebase Function for Storage Deletion.


## :books: Documentation
* Add Firebase Function for Storage Deletion Deployment Workflow


## :white_check_mark: Testing
https://github.com/StanfordBDHG/RadGPT/actions/runs/13575279603

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
