### PR TITLE
Fix long questions alignment

### DIFF
--- a/web/src/routes/~_dashboard/QuestionAnswer.tsx
+++ b/web/src/routes/~_dashboard/QuestionAnswer.tsx
@@ -70,7 +70,10 @@ export const QuestionAnswer = ({
 
   return (
     <>
-      <button onClick={onClick} className="interactive-opacity flex flex-row">
+      <button
+        onClick={onClick}
+        className="interactive-opacity flex flex-row text-left"
+      >
         {question}
         {isSelected ?
           <ChevronUp className="ml-auto min-w-8" />


### PR DESCRIPTION
# Fix long questions alignment

## :recycle: Current situation & Problem
> While testing locally I noticed that the questions are getting centered when they are multiple lines long (see picture below)
Can you please fix that?

_Originally posted by @ThomasKaar in https://github.com/StanfordBDHG/RadGPT/pull/66#pullrequestreview-2657518685_

            

## :gear: Release Notes 
* Fix long questions alignment


## :white_check_mark: Testing
Manual

![image](https://github.com/user-attachments/assets/6f3e8852-cdbd-4e2b-add3-bb69d9d9d5ba)



### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
