### PR TITLE
Rotate chevron instead of rendering different one

### DIFF
--- a/web/src/routes/~_dashboard/QuestionAnswer.tsx
+++ b/web/src/routes/~_dashboard/QuestionAnswer.tsx
@@ -11,7 +11,7 @@ import { Input } from "@stanfordspezi/spezi-web-design-system/components/Input";
 import { toast } from "@stanfordspezi/spezi-web-design-system/components/Toaster";
 import { Field, useForm } from "@stanfordspezi/spezi-web-design-system/forms";
 import { cn } from "@stanfordspezi/spezi-web-design-system/utils/className";
-import { ChevronDown, ChevronUp, ThumbsDown, ThumbsUp } from "lucide-react";
+import { ChevronDown, ThumbsDown, ThumbsUp } from "lucide-react";
 import { useEffect, useRef, useState, type MouseEventHandler } from "react";
 import { z } from "zod";
 


### PR DESCRIPTION
# Rotate chevron instead of rendering different one

## :recycle: Current situation & Problem
If chevron SVG is programmatically changed up/down it cannot be animated.


## :gear: Release Notes 
* Rotate chevron instead of rendering different one


## :white_check_mark: Testing

https://github.com/user-attachments/assets/6f89dc1d-3168-46bb-8eb9-9c664465e5e7


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
