### PR TITLE
Fix Long File Names

### DIFF
--- a/web/src/routes/~_dashboard/FileList.tsx
+++ b/web/src/routes/~_dashboard/FileList.tsx
@@ -38,7 +38,7 @@ export const FileList = ({
           <button
             onClick={() => setSelectedFile(item.ref)}
             className={cn(
-              "interactive-opacity",
+              "interactive-opacity text-left",
               item.ref?.name === selectedFile?.name && "font-bold",
             )}
           >


### PR DESCRIPTION
Stacked PRs:
 * #73
 * __->__#74
 * #72


--- --- ---

# Fix Long File Names

## :recycle: Current situation & Problem
For long file names the is aligned to the center instead of the left (see testing below).

## :books: Documentation
* Fix analog to #69

## :white_check_mark: Testing
|Before|After|
|--|--|
|<img width="1511" alt="image" src="https://github.com/user-attachments/assets/4f80a5a5-69a1-428f-ad4b-bd756ff29176" />|<img width="1511" alt="image" src="https://github.com/user-attachments/assets/ab46ea91-80ad-46bd-bdc0-103ca5f79d5f" />|


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).