### PR TITLE
Add Upload Limiter

### DIFF
--- a/firebase/functions/function_implementation/tests/unit/test_on_medical_report_upload.py
+++ b/firebase/functions/function_implementation/tests/unit/test_on_medical_report_upload.py
@@ -41,6 +41,76 @@ def test_invalid_path(mocker, uid, report_hash):
     on_medical_report_upload_impl(mock_event)
 
 
+@pytest.mark.parametrize(
+    "is_report_gpt_valid",
+    [True, False],
+)
+def test_upload_limiter_failed(mocker, is_report_gpt_valid):
+    bucket = "<bucket>"
+    uid = "<uid>"
+    report_hash = "<report_hash>"
+    user_provided_report = "<user_provided_report>"
+    mock_event = mocker.MagicMock()
+    mock_event.data.name = f"users/{uid}/reports/{report_hash}"
+    mock_event.data.bucket = bucket
+
+    mocked_get_report_from_cloud_storage_function = mocker.patch(
+        "function_implementation.on_medical_report_upload.__get_report_from_cloud_storage",
+        return_value=user_provided_report,
+    )
+
+    mocked_set_report_meta_data_function = mocker.patch(
+        "function_implementation.on_medical_report_upload.__set_report_meta_data",
+    )
+
+    processed_annotation = "<processed_annotation>"
+    text_mapping = "<text_mapping>"
+    mocked_get_postprocessed_annotation = mocker.patch(
+        "function_implementation.on_medical_report_upload.__get_postprocessed_annotations",
+        return_value=(processed_annotation, text_mapping),
+    )
+
+    mocked_update_report_meta_data_function = mocker.patch(
+        "function_implementation.on_medical_report_upload.__update_report_meta_data",
+    )
+
+    mocked_request_report_validation_function = mocker.patch(
+        "function_implementation.on_medical_report_upload.request_report_validation",
+        return_value=is_report_gpt_valid,
+    )
+
+    mocked__is_upload_limiter_valid_function = mocker.patch(
+        "function_implementation.on_medical_report_upload.__is_upload_limiter_valid",
+        return_value=False,
+    )
+
+    on_medical_report_upload_impl(mock_event)
+
+    mocked_get_report_from_cloud_storage_function.assert_called_once_with(
+        bucket, pathlib.PurePath(mock_event.data.name)
+    )
+
+    mocked_set_report_meta_data_function.assert_called_once_with(
+        uid,
+        report_hash,
+        {
+            "user_provided_text": user_provided_report,
+        },
+    )
+
+    mocked_get_postprocessed_annotation.assert_not_called()
+
+    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_hash)
+
+    mocked_request_report_validation_function.assert_not_called()
+
+    mocked_update_report_meta_data_function.assert_called_once_with(
+        uid,
+        report_hash,
+        {"error_code": ErrorCode.UPLOAD_LIMIT_REACHED.value},
+    )
+
+
 def test_gpt_validation_failed(mocker):
     bucket = "<bucket>"
     uid = "<uid>"
@@ -75,6 +145,11 @@ def test_gpt_validation_failed(mocker):
         return_value=False,
     )
 
+    mocked__is_upload_limiter_valid_function = mocker.patch(
+        "function_implementation.on_medical_report_upload.__is_upload_limiter_valid",
+        return_value=True,
+    )
+
     on_medical_report_upload_impl(mock_event)
 
     mocked_get_report_from_cloud_storage_function.assert_called_once_with(
@@ -90,6 +165,8 @@ def test_gpt_validation_failed(mocker):
     )
 
     mocked_get_postprocessed_annotation.assert_not_called()
+
+    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_hash)
 
     mocked_request_report_validation_function.assert_called_once_with(
         user_provided_report
@@ -131,9 +208,13 @@ def test_mocked_flow(mocker):
         "function_implementation.on_medical_report_upload.__update_report_meta_data",
     )
 
-    # todo add e2e test
     mocked_request_report_validation_function = mocker.patch(
         "function_implementation.on_medical_report_upload.request_report_validation",
+        return_value=True,
+    )
+
+    mocked__is_upload_limiter_valid_function = mocker.patch(
+        "function_implementation.on_medical_report_upload.__is_upload_limiter_valid",
         return_value=True,
     )
 
@@ -156,6 +237,8 @@ def test_mocked_flow(mocker):
     mocked_request_report_validation_function.assert_called_once_with(
         user_provided_report
     )
+
+    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_hash)
 
     mocked_update_report_meta_data_function.assert_called_once_with(
         uid,

--- a/web/e2e-tests/tests/uploadMoreThanUploadLimit.spec.ts
+++ b/web/e2e-tests/tests/uploadMoreThanUploadLimit.spec.ts
@@ -1,0 +1,39 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health RadGPT open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { test, expect } from "@playwright/test";
+import { addNewReport, authenticateWithGoogle } from "../utils";
+
+const MAX_UPLOAD_LIMIT = 5;
+
+test("Test Upload Above Upload Limiting", async ({ page }) => {
+  await authenticateWithGoogle(page);
+  for (let i = 0; i < MAX_UPLOAD_LIMIT; i++) {
+    const reportContent =
+      `Report ${i}:\n` +
+      "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract.";
+    await addNewReport(page, {
+      name: "Abdomen CT " + i,
+      content: reportContent,
+    });
+    await expect(page.getByText(`Report ${i}`)).toBeVisible();
+
+    await expect(page.getByText("FeedbackSubmit")).toBeVisible();
+  }
+  const reportContent =
+    `Report ${MAX_UPLOAD_LIMIT}:\n` +
+    "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract.";
+  await addNewReport(page, {
+    name: "Abdomen CT " + MAX_UPLOAD_LIMIT,
+    content: reportContent,
+  });
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText(
+    "You have reached your limit for radiology report uploads. In case you believe this is a mistake or if you want to file for an exemption, please send a brief email to",
+  );
+});

--- a/web/src/modules/files/processedAnnotations.ts
+++ b/web/src/modules/files/processedAnnotations.ts
@@ -21,6 +21,7 @@ export interface ProcessedAnnotations {
 
 export enum AnnotationProcessingError {
   validationFailed = 1,
+  uploadLimitReached = 2,
 }
 
 // Source: https://github.com/JacobWeisenburger/zod_utilz/blob/4093595e5a6d95770872598ba3bc405d4e9c963b/src/stringToJSON.ts#LL4-L12C8

--- a/web/src/routes/~_dashboard/~file/ReportText.tsx
+++ b/web/src/routes/~_dashboard/~file/ReportText.tsx
@@ -25,6 +25,8 @@ interface ReportTextProp {
 const errorCodeToString: Record<AnnotationProcessingError, string> = {
   [AnnotationProcessingError.validationFailed]:
     "This report could not be identified as a radiology report. In case you believe this is a mistake, please send a brief email to ...",
+  [AnnotationProcessingError.uploadLimitReached]:
+    "You have reached your limit for radiology report uploads. In case you believe this is a mistake or if you want to file for an exemption, please send a brief email to ...",
 };
 
 export const ReportText = ({ file }: ReportTextProp) => {


### PR DESCRIPTION
Stacked PRs:
 * __->__#75
 * #73


--- --- ---

# Add Rate Limiter

## :recycle: Current situation & Problem
Currently, users can upload reports infinitely without any restrictions. Therefore, we want to introduce rate limiting for report uploads.

## :books: Documentation
* Add Firestore data model for rate limit
* Add e2e test

## :white_check_mark: Testing
<img width="3006" alt="image" src="https://github.com/user-attachments/assets/3f686d2d-5f8f-4fac-ba7f-8ddc1c1852f1" />


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).