### PR TITLE
Enhance Accessibility and Add useMemo in ReportText

### DIFF
--- a/web/src/routes/~_dashboard/AddFileButton.tsx
+++ b/web/src/routes/~_dashboard/AddFileButton.tsx
@@ -11,6 +11,7 @@ import { Button } from "@stanfordspezi/spezi-web-design-system/components/Button
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -53,6 +54,9 @@ export const AddFileButton = () => {
       <DialogContent className="max-h-screen overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Add New Medical Report</DialogTitle>
+          <DialogDescription>
+            Please insert your radiology report below.
+          </DialogDescription>
         </DialogHeader>
         <FileCreationForm
           onUploadSuccess={onUploadSuccessDialogClose}

--- a/web/src/routes/~_dashboard/QuestionAnswer.tsx
+++ b/web/src/routes/~_dashboard/QuestionAnswer.tsx
@@ -87,6 +87,7 @@ export const QuestionAnswer = ({
         ref={ref}
         style={{ height }}
         className="overflow-hidden border-b border-slate-200 duration-200"
+        hidden={!isSelected}
       >
         <div className="text-md text-gray-700">
           {answer}

--- a/web/src/routes/~_dashboard/~file/DetailDialog.tsx
+++ b/web/src/routes/~_dashboard/~file/DetailDialog.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@stanfordspezi/spezi-web-design-system/components/Dialog";
@@ -137,53 +138,56 @@ export const DetailDialog = ({
       <DialogContent className="max-h-screen min-w-[50%] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Detailed Explanation</DialogTitle>
-          <Async
-            {...queriesToAsyncProps([detailedExplanationQuery, feedbackQuery])}
-          >
-            <p>{main_explanation}</p>
-            {concept_question_1 && concept_answer_1 && (
-              <h3 className="text-lg font-semibold">
-                Other questions you may have
-              </h3>
-            )}
-            {concept_question_1 && concept_answer_1 && (
-              <QuestionAnswer
-                onClick={() =>
-                  selectedNumber === 1 ?
-                    setSelectedNumber(undefined)
-                  : setSelectedNumber(1)
-                }
-                isSelected={selectedNumber === 1}
-                question={concept_question_1}
-                answer={concept_answer_1}
-                onLike={createOnLike(1)}
-                onDislike={createOnDislike(1)}
-                like={like1}
-                dislike={dislike1}
-                textFeedback={textFeedback1}
-                onFeedbackSubmit={createOnFeedback(1)}
-              />
-            )}
-            {concept_question_2 && concept_answer_2 && (
-              <QuestionAnswer
-                onClick={() =>
-                  selectedNumber === 2 ?
-                    setSelectedNumber(undefined)
-                  : setSelectedNumber(2)
-                }
-                isSelected={selectedNumber === 2}
-                question={concept_question_2}
-                answer={concept_answer_2}
-                onLike={createOnLike(2)}
-                onDislike={createOnDislike(2)}
-                like={like2}
-                dislike={dislike2}
-                textFeedback={textFeedback2}
-                onFeedbackSubmit={createOnFeedback(2)}
-              />
-            )}
-          </Async>
+          <DialogDescription>
+            You can find a detailed explanation of the selected concept.
+          </DialogDescription>
         </DialogHeader>
+        <Async
+          {...queriesToAsyncProps([detailedExplanationQuery, feedbackQuery])}
+        >
+          <p>{main_explanation}</p>
+          {concept_question_1 && concept_answer_1 && (
+            <h3 className="text-lg font-semibold">
+              Other questions you may have
+            </h3>
+          )}
+          {concept_question_1 && concept_answer_1 && (
+            <QuestionAnswer
+              onClick={() =>
+                selectedNumber === 1 ?
+                  setSelectedNumber(undefined)
+                : setSelectedNumber(1)
+              }
+              isSelected={selectedNumber === 1}
+              question={concept_question_1}
+              answer={concept_answer_1}
+              onLike={createOnLike(1)}
+              onDislike={createOnDislike(1)}
+              like={like1}
+              dislike={dislike1}
+              textFeedback={textFeedback1}
+              onFeedbackSubmit={createOnFeedback(1)}
+            />
+          )}
+          {concept_question_2 && concept_answer_2 && (
+            <QuestionAnswer
+              onClick={() =>
+                selectedNumber === 2 ?
+                  setSelectedNumber(undefined)
+                : setSelectedNumber(2)
+              }
+              isSelected={selectedNumber === 2}
+              question={concept_question_2}
+              answer={concept_answer_2}
+              onLike={createOnLike(2)}
+              onDislike={createOnDislike(2)}
+              like={like2}
+              dislike={dislike2}
+              textFeedback={textFeedback2}
+              onFeedbackSubmit={createOnFeedback(2)}
+            />
+          )}
+        </Async>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Stacked PRs:
 * #82
 * #83
 * __->__#81


--- --- ---

# Enhance Accessibility and Add useMemo in ReportText

## :recycle: Current situation & Problem
Currently, the text mapping is getting recalculated on each rerender which is quite inefficient. Additionally, the Radgraph-identified keywords are not highlighted correctly when using tab which is an accessibility bug.

## :books: Documentation
* Add description for dialogs
* Refactor `ReportText.tsx` to use `useMemo` to reduce computation efforts on rerenders which are happening on mouse movement over keywords
* Add correct keyword highlighting with the `onFocus` event listener
* Enhance accessibility focus for `QuestionAnswer`


## :white_check_mark: Testing
*Before*

https://github.com/user-attachments/assets/f39fd0e5-b1d4-4b4f-a349-d503fa79321f

https://github.com/user-attachments/assets/cc00f285-f4bd-419f-ac39-b06e33bccbcf




*After*

https://github.com/user-attachments/assets/ddfc2892-a386-4d02-b81a-985dea5ebfe9 

https://github.com/user-attachments/assets/cea442d0-c80d-44e8-8c9c-c1ad6ae5f756




### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).