### PR TITLE
Enhance Robustness of E2E Tests

### DIFF
--- a/.github/workflows/build-and-test.firebase.yml
+++ b/.github/workflows/build-and-test.firebase.yml
@@ -14,8 +14,6 @@ concurrency:
 
 on:
   pull_request:
-    paths:
-        - firebase/**
   workflow_dispatch:
   workflow_call:
 
@@ -37,8 +35,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'npm'
+          node-version: "18"
+          cache: "npm"
           cache-dependency-path: firebase/package-lock.json
       - name: Install Node Dependencies
         run: npm ci
@@ -57,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install the code linting and formatting tool Ruff
         run: pipx install ruff
       - name: Lint code with Ruff
@@ -70,19 +68,19 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: 'firebase'
+        working-directory: "firebase"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Setup Python Virutal Environment
         working-directory: firebase
         run: |
           python3.10 -m venv functions/venv
           . functions/venv/bin/activate
-          python3.10 -m pip install -r functions/requirements-test.txt 
+          python3.10 -m pip install -r functions/requirements-test.txt
       - name: Run PyTest
         working-directory: firebase
         run: |

--- a/.github/workflows/build-and-test.web.yml
+++ b/.github/workflows/build-and-test.web.yml
@@ -14,8 +14,6 @@ concurrency:
 
 on:
   pull_request:
-    paths:
-        - web/**
   workflow_dispatch:
   workflow_call:
 

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 
 # Jetbrains IDE
 .idea/
+
+node_modules/

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -10,6 +10,6 @@ dirs:
   - .
 useGitIgnore: true
 ignorePatterns:
-  - pattern: '^doc:.*$'
-  - pattern: '^http://localhost.*$'
-  - pattern: '^https://.*openai\.com'
+  - pattern: "doc:/"
+  - pattern: "http://localhost"
+  - pattern: "openai.com"

--- a/web/e2e-tests/package-lock.json
+++ b/web/e2e-tests/package-lock.json
@@ -9,25 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@playwright/test": "^1.49.1"
+        "crypto": "^1.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.2"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
@@ -40,49 +25,12 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "license": "ISC"
     },
     "node_modules/undici-types": {
       "version": "6.20.0",

--- a/web/e2e-tests/package.json
+++ b/web/e2e-tests/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@playwright/test": "^1.49.1"
+    "crypto": "^1.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2"

--- a/web/e2e-tests/tests/uploadDeletionFlow.spec.ts
+++ b/web/e2e-tests/tests/uploadDeletionFlow.spec.ts
@@ -7,43 +7,46 @@
 //
 
 import { test, expect } from "@playwright/test";
-import { addNewReport, authenticateWithGoogle } from "../utils";
+import {
+  addNewReport,
+  authenticateWithGoogle,
+  checkForTextAnnotationCompletion,
+} from "../utils";
 
 test("Test Upload and Deletion Flow", async ({ page }) => {
   await authenticateWithGoogle(page);
   await expect(page.getByText(/Please add or select a report./)).toBeVisible();
+
   await addNewReport(page, {
     name: "Abdomen CT",
     content:
       "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract.",
   });
-  await expect(page.getByText(/Study Type: CT Abdomen and/)).toBeVisible();
-  await expect(page.getByText("FeedbackSubmit")).toBeVisible();
+  await checkForTextAnnotationCompletion(page, /Study Type: CT Abdomen and/);
+
   await addNewReport(page, {
     name: "Hypodense Lesion",
     content:
       "Hypodense lesion is observed in the right hepatic lobe, measuring 2.5 cm and appearing non-enhancing on contrast-enhanced imaging, suggestive of a benign cyst.",
   });
-  await expect(page.getByText("Hypodense lesion is observed")).toBeVisible();
-  await page.getByText("FeedbackSubmit").click();
-  await expect(page.getByText("FeedbackSubmit")).toBeVisible();
+  await checkForTextAnnotationCompletion(page, "Hypodense lesion is observed");
+
   const getUpload = (hasText: RegExp) =>
     page.locator("div").filter({ hasText }).nth(0);
   await expect(getUpload(/^Abdomen CT$/)).toBeVisible();
   await expect(getUpload(/^Hypodense Lesion$/)).toBeVisible();
-  await getUpload(/^Abdomen CT$/)
-    .getByLabel("Delete")
-    .click();
-  await expect(
-    page.locator("div").filter({ hasText: /^Abdomen CT$/ }),
-  ).toHaveCount(0);
-  await expect(getUpload(/^Hypodense Lesion$/)).toBeVisible();
   await getUpload(/^Hypodense Lesion$/)
     .getByLabel("Delete")
     .click();
-  await expect(
-    page.locator("div").filter({ hasText: /^Hypodense Lesion$/ }),
-  ).toHaveCount(0);
+  await page.waitForURL("/");
+
+  await expect(getUpload(/^Hypodense Lesion$/)).not.toBeVisible();
+  await expect(getUpload(/^Abdomen CT$/)).toBeVisible();
+  await getUpload(/^Abdomen CT$/)
+    .getByLabel("Delete")
+    .click();
+  await expect(getUpload(/^Hypodense Lesion$/)).not.toBeVisible();
+  await expect(getUpload(/^Abdomen CT$/)).not.toBeVisible();
   await expect(page.getByText("No reports found.").first()).toBeVisible();
   await page.getByTestId("user-menu").first().click();
   await expect(page.getByText("Sign Out")).toBeVisible();

--- a/web/e2e-tests/tests/uploadDetailedInformationFlow.spec.ts
+++ b/web/e2e-tests/tests/uploadDetailedInformationFlow.spec.ts
@@ -7,16 +7,23 @@
 //
 
 import { test, expect } from "@playwright/test";
-import { addNewReport, authenticateWithGoogle } from "../utils";
+import {
+  addNewReport,
+  authenticateWithGoogle,
+  checkForTextAnnotationCompletion,
+} from "../utils";
 
 test("Test Upload and GPT Detailed Information Flow", async ({ page }) => {
   test.setTimeout(60_000);
   await authenticateWithGoogle(page);
+
   await addNewReport(page, {
     name: "Medical Report",
     content:
       "\nStudy Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\n\nFindings:\n\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\n\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\n\nImpression:\n\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract.",
   });
+  await checkForTextAnnotationCompletion(page, /Study Type: CT Abdomen and/);
+
   await page.getByText("Small", { exact: true }).click({ timeout: 60_000 });
   await expect(page.getByRole("heading")).toContainText("Detailed Explanation");
   await expect(

--- a/web/e2e-tests/tests/uploadDuplicateMedicalReportFlow.spec.ts
+++ b/web/e2e-tests/tests/uploadDuplicateMedicalReportFlow.spec.ts
@@ -7,32 +7,54 @@
 //
 
 import { test, expect } from "@playwright/test";
-import { addNewReport, authenticateWithGoogle } from "../utils";
+import {
+  addNewReport,
+  authenticateWithGoogle,
+  calculateSHA256Hash,
+  checkForTextAnnotationCompletion,
+} from "../utils";
 
 test("Test Duplicate Medical Report Upload", async ({ page }) => {
   await authenticateWithGoogle(page);
+
+  const duplicateReportContent =
+    "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract";
+
   await addNewReport(page, {
     name: "CT Abdomen",
-    content:
-      "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract",
+    content: duplicateReportContent,
   });
+  await checkForTextAnnotationCompletion(
+    page,
+    "Study Type: CT Abdomen and Pelvis",
+  );
+
   await addNewReport(page, {
     name: "Hypodense Lesion",
     content:
       "Hypodense lesion is observed in the right hepatic lobe, measuring 2.5 cm and appearing non-enhancing on contrast-enhanced imaging, suggestive of a benign cyst.",
   });
+  await checkForTextAnnotationCompletion(
+    page,
+    "Hypodense lesion is observed in the",
+  );
+
   await addNewReport(page, {
     name: "Duplicated Report",
-    content:
-      "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract",
+    content: duplicateReportContent,
   });
   await expect(
     page.getByText(
       "This medical report has already been uploaded. It has now been selected.",
     ),
   ).toBeVisible();
+  await page.waitForURL(`file/${calculateSHA256Hash(duplicateReportContent)}`);
   await expect(page.locator("#root")).toContainText(
     "Study Type: CT Abdomen and Pelvis Indication: Evaluation for kidney stones due to symptoms of flank pain and hematuria. Findings: The kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter. In the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall. Impression: Small non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary. No other abnormalities detected in the kidneys or urinary tract",
   );
   await expect(page.getByText("Duplicated Report")).not.toBeVisible();
+  await checkForTextAnnotationCompletion(
+    page,
+    "Study Type: CT Abdomen and Pelvis",
+  );
 });

--- a/web/e2e-tests/tests/uploadInvalidRadiologyReport.spec.ts
+++ b/web/e2e-tests/tests/uploadInvalidRadiologyReport.spec.ts
@@ -16,7 +16,7 @@ test("Test Invalid Radiology Report Upload", async ({ page }) => {
     content:
       'The Equation of Everything\n\nDr. Elias Carter stared at the board, his chalk-streaked fingers trembling. The equation was almost complete—a bridge between quantum mechanics and relativity. The fabled "Theory of Everything."\n\nFor centuries, physicists sought a unifying law, a mathematical truth that could explain the forces of nature, from the dance of galaxies to the spin of electrons. Elias had spent his life pursuing this dream, lost in numbers, driven by an obsession that had cost him friendships, love, and time itself.\n\nHis breakthrough had come unexpectedly, in a dream. He saw the universe as a vast tensor field, woven together by geometric symmetries beyond human intuition. Waking up, he scrawled the final term onto the board.\n\nThe room trembled. Space itself seemed to ripple. The symbols burned into his mind as if they had always been there, waiting to be written.\n\nA sudden realization struck him—the equation didn’t just describe reality; it was reality. By solving it, he had rewritten the cosmos itself.\n\nA light enveloped him, and he felt himself dissolving, merging into the fabric of existence, becoming the very mathematics he had once sought to understand.\n\nAnd then—nothing.\n\nOnly the equation remained.',
   });
-  await page.getByRole("alert").isVisible();
+  await expect(page.getByRole("alert")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByRole("alert")).toContainText(
     "This report could not be identified as a radiology report. In case you believe this is a mistake, please send a brief email to",
   );

--- a/web/e2e-tests/tests/uploadMoreThanUploadLimit.spec.ts
+++ b/web/e2e-tests/tests/uploadMoreThanUploadLimit.spec.ts
@@ -7,7 +7,11 @@
 //
 
 import { test, expect } from "@playwright/test";
-import { addNewReport, authenticateWithGoogle } from "../utils";
+import {
+  addNewReport,
+  authenticateWithGoogle,
+  checkForTextAnnotationCompletion,
+} from "../utils";
 
 const MAX_UPLOAD_LIMIT = 5;
 
@@ -21,9 +25,7 @@ test("Test Upload Above Upload Limiting", async ({ page }) => {
       name: "Abdomen CT " + i,
       content: reportContent,
     });
-    await expect(page.getByText(`Report ${i}`)).toBeVisible();
-
-    await expect(page.getByText("FeedbackSubmit")).toBeVisible();
+    await checkForTextAnnotationCompletion(page, `Report ${i}`);
   }
   const reportContent =
     `Report ${MAX_UPLOAD_LIMIT}:\n` +
@@ -32,7 +34,7 @@ test("Test Upload Above Upload Limiting", async ({ page }) => {
     name: "Abdomen CT " + MAX_UPLOAD_LIMIT,
     content: reportContent,
   });
-  await expect(page.getByRole("alert")).toBeVisible();
+  await expect(page.getByRole("alert")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByRole("alert")).toContainText(
     "You have reached your limit for radiology report uploads. In case you believe this is a mistake or if you want to file for an exemption, please send a brief email to",
   );

--- a/web/e2e-tests/utils.ts
+++ b/web/e2e-tests/utils.ts
@@ -6,13 +6,16 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { type Page } from "@playwright/test";
+import { type Page, expect } from "@playwright/test";
+import { createHash } from "crypto";
 
 export const authenticateWithGoogle = async (page: Page) => {
   await page.goto("/signin?redirect=%2F");
   const page1Promise = page.waitForEvent("popup");
+  await page.waitForLoadState();
   await page.getByRole("button", { name: "Sign in with Google" }).click();
   const page1 = await page1Promise;
+  await page1.waitForLoadState();
   await page1.getByRole("button", { name: "Add new account" }).click();
   await page1
     .getByRole("button", { name: "Auto-generate user information" })
@@ -20,6 +23,9 @@ export const authenticateWithGoogle = async (page: Page) => {
   await page1.getByRole("button", { name: "Sign in with Google.com" }).click();
   await page.waitForURL("/");
 };
+
+export const calculateSHA256Hash = (content: string) =>
+  createHash("sha256").update(content).digest("hex");
 
 export const addNewReport = async (
   page: Page,
@@ -29,4 +35,18 @@ export const addNewReport = async (
   await page.getByLabel("Name").fill(content.name);
   await page.getByLabel("Medical Report Content").fill(content.content);
   await page.getByRole("button", { name: "Submit" }).click();
+  await expect(page.getByLabel("Medical Report Content")).not.toBeVisible();
+  await page.waitForURL(`/file/${calculateSHA256Hash(content.content)}`);
+};
+
+export const checkForTextAnnotationCompletion = async (
+  page: Page,
+  title: string | RegExp,
+) => {
+  await expect(page.getByText(title)).toBeVisible();
+
+  await expect(page.getByRole("heading", { name: "Feedback" })).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.locator("form")).toBeVisible();
 };


### PR DESCRIPTION
Stacked PRs:
 * #82
 * __->__#83


--- --- ---

# Enhance Robustness of E2E Tests

## :recycle: Current situation & Problem
Currently, e2e tests are often flaky.


## :books: Documentation
* Add function for checking finished report annotation
* Increase `timeout` for functions that are dependent on OpenAI
* Add `waitForURL`-checks when navigations are happening
* Add more checks that ensure the whole flow is working properly and the correct locators are selected

## :white_check_mark: Testing
`npx playwright test`
see CI

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).