### PR TITLE
Change from SHA256 Hash to UUID for Medical Reports

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -71,7 +71,7 @@ service cloud.firestore {
               && containsOnlyAllowedCachedFields(data);
     } 
 
-    match /users/{userId}/{documentHash}/{documentName} {
+    match /users/{userId}/{documentUUID}/{documentName} {
       allow read: if isAuthenticatedUserID(userId);
       allow update: if isAuthenticatedUserID(userId)
                     && (

--- a/firebase/functions/function_implementation/tests/unit/test_on_medical_report_upload.py
+++ b/firebase/functions/function_implementation/tests/unit/test_on_medical_report_upload.py
@@ -17,20 +17,20 @@ from function_implementation.on_medical_report_upload import (
 
 
 @pytest.mark.parametrize(
-    "uid,report_hash",
+    "uid,report_uuid",
     [
-        (uid, report_hash)
+        (uid, report_uuid)
         for uid in ["<uid>", "", None]
-        for report_hash in ["<report_hash>", None]
-        if not (uid == "<uid>" and report_hash == "<report_hash>")
+        for report_uuid in ["<report_uuid>", None]
+        if not (uid == "<uid>" and report_uuid == "<report_uuid>")
     ],
 )
-def test_invalid_path(mocker, uid, report_hash):
+def test_invalid_path(mocker, uid, report_uuid):
     bucket = "<bucket>"
     mock_event = mocker.MagicMock()
     uid_segement = f"{uid}/" if uid is not None else ""
-    report_hash_segment = report_hash if report_hash is not None else ""
-    mock_event.data.name = f"users/{uid_segement}reports/{report_hash_segment}"
+    report_uuid_segment = report_uuid if report_uuid is not None else ""
+    mock_event.data.name = f"users/{uid_segement}reports/{report_uuid_segment}"
     mock_event.data.bucket = bucket
 
     mocked_function = mocker.patch(
@@ -48,10 +48,10 @@ def test_invalid_path(mocker, uid, report_hash):
 def test_upload_limiter_failed(mocker, is_report_gpt_valid):
     bucket = "<bucket>"
     uid = "<uid>"
-    report_hash = "<report_hash>"
+    report_uuid = "<report_uuid>"
     user_provided_report = "<user_provided_report>"
     mock_event = mocker.MagicMock()
-    mock_event.data.name = f"users/{uid}/reports/{report_hash}"
+    mock_event.data.name = f"users/{uid}/reports/{report_uuid}"
     mock_event.data.bucket = bucket
 
     mocked_get_report_from_cloud_storage_function = mocker.patch(
@@ -92,7 +92,7 @@ def test_upload_limiter_failed(mocker, is_report_gpt_valid):
 
     mocked_set_report_meta_data_function.assert_called_once_with(
         uid,
-        report_hash,
+        report_uuid,
         {
             "user_provided_text": user_provided_report,
         },
@@ -100,13 +100,13 @@ def test_upload_limiter_failed(mocker, is_report_gpt_valid):
 
     mocked_get_postprocessed_annotation.assert_not_called()
 
-    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_hash)
+    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_uuid)
 
     mocked_request_report_validation_function.assert_not_called()
 
     mocked_update_report_meta_data_function.assert_called_once_with(
         uid,
-        report_hash,
+        report_uuid,
         {"error_code": ErrorCode.UPLOAD_LIMIT_REACHED.value},
     )
 
@@ -114,10 +114,10 @@ def test_upload_limiter_failed(mocker, is_report_gpt_valid):
 def test_gpt_validation_failed(mocker):
     bucket = "<bucket>"
     uid = "<uid>"
-    report_hash = "<report_hash>"
+    report_uuid = "<report_uuid>"
     user_provided_report = "<user_provided_report>"
     mock_event = mocker.MagicMock()
-    mock_event.data.name = f"users/{uid}/reports/{report_hash}"
+    mock_event.data.name = f"users/{uid}/reports/{report_uuid}"
     mock_event.data.bucket = bucket
 
     mocked_get_report_from_cloud_storage_function = mocker.patch(
@@ -158,7 +158,7 @@ def test_gpt_validation_failed(mocker):
 
     mocked_set_report_meta_data_function.assert_called_once_with(
         uid,
-        report_hash,
+        report_uuid,
         {
             "user_provided_text": user_provided_report,
         },
@@ -166,7 +166,7 @@ def test_gpt_validation_failed(mocker):
 
     mocked_get_postprocessed_annotation.assert_not_called()
 
-    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_hash)
+    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_uuid)
 
     mocked_request_report_validation_function.assert_called_once_with(
         user_provided_report
@@ -174,7 +174,7 @@ def test_gpt_validation_failed(mocker):
 
     mocked_update_report_meta_data_function.assert_called_once_with(
         uid,
-        report_hash,
+        report_uuid,
         {"error_code": ErrorCode.VALIDATION_FAILED.value},
     )
 
@@ -182,10 +182,10 @@ def test_gpt_validation_failed(mocker):
 def test_mocked_flow(mocker):
     bucket = "<bucket>"
     uid = "<uid>"
-    report_hash = "<report_hash>"
+    report_uuid = "<report_uuid>"
     user_provided_report = "<user_provided_report>"
     mock_event = mocker.MagicMock()
-    mock_event.data.name = f"users/{uid}/reports/{report_hash}"
+    mock_event.data.name = f"users/{uid}/reports/{report_uuid}"
     mock_event.data.bucket = bucket
 
     mocked_get_report_from_cloud_storage_function = mocker.patch(
@@ -226,7 +226,7 @@ def test_mocked_flow(mocker):
 
     mocked_set_report_meta_data_function.assert_called_once_with(
         uid,
-        report_hash,
+        report_uuid,
         {
             "user_provided_text": user_provided_report,
         },
@@ -238,11 +238,11 @@ def test_mocked_flow(mocker):
         user_provided_report
     )
 
-    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_hash)
+    mocked__is_upload_limiter_valid_function.assert_called_once_with(uid, report_uuid)
 
     mocked_update_report_meta_data_function.assert_called_once_with(
         uid,
-        report_hash,
+        report_uuid,
         {
             "processed_annotations": json.dumps(processed_annotation),
             "text_mapping": text_mapping,

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -14,7 +14,7 @@ service firebase.storage {
       return request.auth != null && request.auth.uid == userId;
     }
 
-    match /users/{userId}/reports/{reportHash} {
+    match /users/{userId}/reports/{reportUUID} {
       allow read: if isAuthenticatedUserID(userId);
       allow create: if isAuthenticatedUserID(userId)
                     && request.resource.contentType.matches("text/plain")

--- a/web/e2e-tests/tests/reportIssueFlow.spec.ts
+++ b/web/e2e-tests/tests/reportIssueFlow.spec.ts
@@ -18,11 +18,11 @@ test("Test Reporting Flow", async ({ page }) => {
   await authenticateWithGoogle(page);
   await expectNoReports(page);
 
-  await addNewReport(page, {
+  void (await addNewReport(page, {
     name: "Abdomen CT",
     content:
       "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract.",
-  });
+  }));
   await checkForTextAnnotationCompletion(page, /Study Type: CT Abdomen and/);
 
   const getUpload = (hasText: RegExp) =>

--- a/web/e2e-tests/tests/uploadDeletionFlow.spec.ts
+++ b/web/e2e-tests/tests/uploadDeletionFlow.spec.ts
@@ -18,18 +18,18 @@ test("Test Upload and Deletion Flow", async ({ page }) => {
   await authenticateWithGoogle(page);
   await expectNoReports(page);
 
-  await addNewReport(page, {
+  void (await addNewReport(page, {
     name: "Abdomen CT",
     content:
       "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract.",
-  });
+  }));
   await checkForTextAnnotationCompletion(page, /Study Type: CT Abdomen and/);
 
-  await addNewReport(page, {
+  void (await addNewReport(page, {
     name: "Hypodense Lesion",
     content:
       "Hypodense lesion is observed in the right hepatic lobe, measuring 2.5 cm and appearing non-enhancing on contrast-enhanced imaging, suggestive of a benign cyst.",
-  });
+  }));
   await checkForTextAnnotationCompletion(page, "Hypodense lesion is observed");
 
   const getUpload = (hasText: RegExp) =>

--- a/web/e2e-tests/tests/uploadDetailedInformationFlow.spec.ts
+++ b/web/e2e-tests/tests/uploadDetailedInformationFlow.spec.ts
@@ -17,11 +17,11 @@ test("Test Upload and GPT Detailed Information Flow", async ({ page }) => {
   test.setTimeout(60_000);
   await authenticateWithGoogle(page);
 
-  await addNewReport(page, {
+  void (await addNewReport(page, {
     name: "Medical Report",
     content:
       "\nStudy Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\n\nFindings:\n\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\n\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\n\nImpression:\n\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract.",
-  });
+  }));
   await checkForTextAnnotationCompletion(page, /Study Type: CT Abdomen and/);
 
   await page.getByText("Small", { exact: true }).click({ timeout: 60_000 });

--- a/web/e2e-tests/tests/uploadDuplicateMedicalReportFlow.spec.ts
+++ b/web/e2e-tests/tests/uploadDuplicateMedicalReportFlow.spec.ts
@@ -10,7 +10,6 @@ import { test, expect } from "@playwright/test";
 import {
   addNewReport,
   authenticateWithGoogle,
-  calculateSHA256Hash,
   checkForTextAnnotationCompletion,
 } from "../utils";
 
@@ -20,7 +19,7 @@ test("Test Duplicate Medical Report Upload", async ({ page }) => {
   const duplicateReportContent =
     "Study Type: CT Abdomen and Pelvis\nIndication: Evaluation for kidney stones due to symptoms of flank pain and hematuria.\nFindings:\nThe kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter.\nIn the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall.\nImpression:\nSmall non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary.\nNo other abnormalities detected in the kidneys or urinary tract";
 
-  await addNewReport(page, {
+  const duplicateReportFirstUploadURL = await addNewReport(page, {
     name: "CT Abdomen",
     content: duplicateReportContent,
   });
@@ -29,17 +28,17 @@ test("Test Duplicate Medical Report Upload", async ({ page }) => {
     "Study Type: CT Abdomen and Pelvis",
   );
 
-  await addNewReport(page, {
+  void (await addNewReport(page, {
     name: "Hypodense Lesion",
     content:
       "Hypodense lesion is observed in the right hepatic lobe, measuring 2.5 cm and appearing non-enhancing on contrast-enhanced imaging, suggestive of a benign cyst.",
-  });
+  }));
   await checkForTextAnnotationCompletion(
     page,
     "Hypodense lesion is observed in the",
   );
 
-  await addNewReport(page, {
+  const duplicateReportSecondUploadURL = await addNewReport(page, {
     name: "Duplicated Report",
     content: duplicateReportContent,
   });
@@ -48,7 +47,11 @@ test("Test Duplicate Medical Report Upload", async ({ page }) => {
       "This medical report has already been uploaded. It has now been selected.",
     ),
   ).toBeVisible();
-  await page.waitForURL(`file/${calculateSHA256Hash(duplicateReportContent)}`);
+
+  expect(duplicateReportSecondUploadURL).toEqual(
+    duplicateReportSecondUploadURL,
+  );
+  await page.waitForURL(duplicateReportFirstUploadURL);
   await expect(page.locator("#root")).toContainText(
     "Study Type: CT Abdomen and Pelvis Indication: Evaluation for kidney stones due to symptoms of flank pain and hematuria. Findings: The kidneys appear normal in size, shape, and position. There is no evidence of hydronephrosis, masses, or calcifications within either kidney. The renal parenchyma and collecting systems are within normal limits. No signs of renal calculi or obstruction in either ureter. In the urinary bladder, a small, non-obstructing calculus is visualized measuring approximately [size in mm]. The calculus is located in the lower portion of the bladder and is not causing any noticeable obstruction or irritation of the bladder wall. Impression: Small non-obstructing bladder calculus without evidence of associated hydronephrosis or renal calculi. The stone appears benign, and no immediate intervention is necessary. No other abnormalities detected in the kidneys or urinary tract",
   );

--- a/web/e2e-tests/utils.ts
+++ b/web/e2e-tests/utils.ts
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { createHash } from "crypto";
 import { type Page, expect } from "@playwright/test";
 
 export const authenticateWithGoogle = async (page: Page) => {
@@ -28,9 +27,6 @@ export const expectNoReports = async (page: Page) => {
   await expect(page.getByText(/No reports found./).first()).toBeVisible();
 };
 
-export const calculateSHA256Hash = (content: string) =>
-  createHash("sha256").update(content).digest("hex");
-
 export const addNewReport = async (
   page: Page,
   content: { name: string; content: string },
@@ -44,7 +40,8 @@ export const addNewReport = async (
   await dialog.getByLabel("Medical Report Content").fill(content.content);
   await dialog.getByRole("button", { name: "Add report" }).click();
   await expect(page.getByLabel("Medical Report Content")).not.toBeVisible();
-  await page.waitForURL(`/file/${calculateSHA256Hash(content.content)}`);
+  await page.waitForURL(/file\//);
+  return page.url();
 };
 
 export const checkForTextAnnotationCompletion = async (

--- a/web/src/modules/files/queries.ts
+++ b/web/src/modules/files/queries.ts
@@ -57,6 +57,7 @@ const listFiles = async () => {
   const fileList = fileMetadata.sort(metaDataCompare).map((fullMetaData) => ({
     ref: fullMetaData.ref,
     customName: fullMetaData.customMetadata?.medicalReportName ?? "undefined",
+    hash: fullMetaData.customMetadata?.hash ?? "undefined",
   }));
   return fileList;
 };

--- a/web/src/utils/crypto.ts
+++ b/web/src/utils/crypto.ts
@@ -16,3 +16,5 @@ export const calculateSHA256Hash = async (data: string) => {
     .join("");
   return hashHex;
 };
+
+export const randomUUID = () => window.crypto.randomUUID();


### PR DESCRIPTION
Stacked PRs:
 * __->__#87


--- --- ---

# Change from SHA256 Hash to UUID for Medical Reports

## :recycle: Current situation & Problem
By having a SHA256 Hash, we are generating an unique identifier per report. However, since we are also using this hash in the URL for navigation, we want to change the identifier to be random UUID.

## :books: Documentation
* Change from SHA256 hash to UUID
* Adjust E2E test to be independent of the ID generated


## :white_check_mark: Testing

See CI

https://github.com/user-attachments/assets/0542a6a6-e33c-412e-9478-3c6c3b8bfd9c



### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).