### PR TITLE
Fix Loading State for File Changes

### DIFF
--- a/web/src/modules/files/queries.ts
+++ b/web/src/modules/files/queries.ts
@@ -139,7 +139,11 @@ export const useGetFileDetailsSubscription = ({
     });
     const unsubscribe = onSnapshot(fileRef, (snapshot) => {
       const data = snapshot.data();
-      if (ignore || !data) return;
+      if (ignore) return;
+      if (!data) {
+        setFile(undefined);
+        return;
+      }
       const file = parseFileDetails(data, fileName);
       setFile(file);
     });


### PR DESCRIPTION
Stacked PRs:
 * #94
 * #93
 * #92
 * __->__#91


--- --- ---

# Fix Loading State for File Changes

## :recycle: Current situation & Problem
Currently, files are staying in the state of the application which can lead to confusion on the user side since it seems like the application is frozen or did not work accordingly.

Video (a thread sleep of 2 seconds was added to the firebase function locally):

https://github.com/user-attachments/assets/112d6822-b87d-4d99-b73b-b2239d027e8b



## :books: Documentation
* Display loading state while the file is still loading




## :white_check_mark: Testing


https://github.com/user-attachments/assets/f8d9a714-61eb-4e2e-b69e-f41d6ae27ee2


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).