### PR TITLE
Add "create time" Timestamp

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -19,7 +19,8 @@ service cloud.firestore {
              && previousData["concept_question_1"] == data["concept_question_1"]
              && previousData["concept_answer_1"] == data["concept_answer_1"]
              && previousData["concept_question_2"] == data["concept_question_2"]
-             && previousData["concept_answer_2"] == data["concept_answer_2"];
+             && previousData["concept_answer_2"] == data["concept_answer_2"]
+             && previousData["create_time"] == data["create_time"];
     } 
 
     function containsOnlyAllowedCachedFields(data) {
@@ -29,6 +30,7 @@ service cloud.firestore {
           "concept_answer_1",
           "concept_question_2",
           "concept_answer_2",
+          "create_time",
           "feedback"
         ]) && data.keys().hasAll([
           "main_explanation",
@@ -36,6 +38,7 @@ service cloud.firestore {
           "concept_answer_1",
           "concept_question_2",
           "concept_answer_2",
+          "create_time",
           "feedback"
         ]);
     }
@@ -43,7 +46,8 @@ service cloud.firestore {
     function notChangingAnnotationFields(previousData, data) {
       return previousData["processed_annotations"] == data["processed_annotations"]
               && previousData["text_mapping"] == data["text_mapping"]
-              && previousData["user_provided_text"] == data["user_provided_text"];
+              && previousData["user_provided_text"] == data["user_provided_text"]
+              && previousData["create_time"] == data["create_time"];
     } 
 
     function containsOnlyAllowedAnnotationFields(data) {
@@ -51,12 +55,14 @@ service cloud.firestore {
           "processed_annotations", 
           "text_mapping", 
           "user_feedback", 
-          "user_provided_text"
+          "user_provided_text",
+          "create_time"
         ]) && data.keys().hasAll([
           "processed_annotations",
           "text_mapping",
           "user_feedback", 
-          "user_provided_text"
+          "user_provided_text",
+          "create_time"
         ]);
     }
 
@@ -89,13 +95,16 @@ service cloud.firestore {
           "report_id",
           "question_index",
           "observation_index", 
-          "origin"
+          "origin",
+          "create_time"
         ]) && data.keys().hasAll([
           "pre_defined_answers",
           "report_id",
           "user_id",
-          "origin"
-        ]);
+          "origin",
+          "create_time"
+        ])
+          && request.resource.data.create_time == request.time;
     }
 
     match /users_reported_issues/{documentHash} {

--- a/firebase/functions/function_implementation/on_detailed_explanation_request.py
+++ b/firebase/functions/function_implementation/on_detailed_explanation_request.py
@@ -56,7 +56,9 @@ def __store_detailed_response(
     observation_ref = annotations_folder_ref.document(
         f"cached_answer_{observation_index}"
     )
-    observation_ref.set(detailed_response)
+    observation_ref.set(
+        {"create_time": firestore.SERVER_TIMESTAMP, **detailed_response}
+    )
 
 
 def on_detailed_explanation_request_impl(req: https_fn.Request) -> https_fn.Response:

--- a/firebase/functions/function_implementation/on_medical_report_upload.py
+++ b/firebase/functions/function_implementation/on_medical_report_upload.py
@@ -116,6 +116,7 @@ def on_medical_report_upload_impl(
         file_name,
         {
             "user_provided_text": user_provided_report,
+            "create_time": firestore.SERVER_TIMESTAMP,
         },
     )
 

--- a/firebase/functions/function_implementation/tests/unit/test_on_medical_report_upload.py
+++ b/firebase/functions/function_implementation/tests/unit/test_on_medical_report_upload.py
@@ -8,6 +8,7 @@
 
 import json
 import pathlib
+from unittest.mock import ANY
 import pytest
 
 from function_implementation.on_medical_report_upload import (
@@ -93,9 +94,7 @@ def test_upload_limiter_failed(mocker, is_report_gpt_valid):
     mocked_set_report_meta_data_function.assert_called_once_with(
         uid,
         report_uuid,
-        {
-            "user_provided_text": user_provided_report,
-        },
+        {"user_provided_text": user_provided_report, "create_time": ANY},
     )
 
     mocked_get_postprocessed_annotation.assert_not_called()
@@ -159,9 +158,7 @@ def test_gpt_validation_failed(mocker):
     mocked_set_report_meta_data_function.assert_called_once_with(
         uid,
         report_uuid,
-        {
-            "user_provided_text": user_provided_report,
-        },
+        {"user_provided_text": user_provided_report, "create_time": ANY},
     )
 
     mocked_get_postprocessed_annotation.assert_not_called()
@@ -227,9 +224,7 @@ def test_mocked_flow(mocker):
     mocked_set_report_meta_data_function.assert_called_once_with(
         uid,
         report_uuid,
-        {
-            "user_provided_text": user_provided_report,
-        },
+        {"user_provided_text": user_provided_report, "create_time": ANY},
     )
 
     mocked_get_postprocessed_annotation.assert_called_once_with(user_provided_report)

--- a/web/src/routes/~_dashboard/~file/FeedbackDialog/MultiCheckboxFeedbackDialog.test.tsx
+++ b/web/src/routes/~_dashboard/~file/FeedbackDialog/MultiCheckboxFeedbackDialog.test.tsx
@@ -77,6 +77,8 @@ describe("Multi Checkbox Submission to Firestore Test", () => {
             pre_defined_answers: [feedbackLabels[selectedFeedbackLabelIndex]],
             user_inputed_answer: null,
             user_id: uid,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            create_time: expect.anything(),
             ...userFeedbackContext,
           }),
         );
@@ -125,6 +127,8 @@ describe("Multi Checkbox Submission to Firestore Test", () => {
           origin: UserFeedbackOrigin.QuestionAnswerLevel,
           question_index: 4,
           observation_index: 1,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          create_time: expect.anything(),
         });
       });
     }),
@@ -163,6 +167,8 @@ describe("Multi Checkbox Submission to Firestore Test", () => {
         origin: UserFeedbackOrigin.QuestionAnswerLevel,
         question_index: 4,
         observation_index: 1,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        create_time: expect.anything(),
       });
     });
   });

--- a/web/src/routes/~_dashboard/~file/FeedbackDialog/MultiCheckboxFeedbackDialog.tsx
+++ b/web/src/routes/~_dashboard/~file/FeedbackDialog/MultiCheckboxFeedbackDialog.tsx
@@ -22,7 +22,11 @@ import { SideLabel } from "@stanfordspezi/spezi-web-design-system/components/Sid
 import { toast } from "@stanfordspezi/spezi-web-design-system/components/Toaster";
 import { Field, useForm } from "@stanfordspezi/spezi-web-design-system/forms";
 import { useOpenState } from "@stanfordspezi/spezi-web-design-system/utils/useOpenState";
-import { addDoc, type CollectionReference } from "firebase/firestore";
+import {
+  addDoc,
+  serverTimestamp,
+  type CollectionReference,
+} from "firebase/firestore";
 import { type ReactElement, type ComponentProps, type ReactNode } from "react";
 import { z } from "zod";
 import { getCurrentUser } from "@/modules/firebase/app";
@@ -115,6 +119,7 @@ export const MultiCheckboxFeedbackDialog = ({
             selectedAnswersStrings.length ? selectedAnswersStrings : null,
           user_inputed_answer: userInputedAnswer ? userInputedAnswer : null,
           user_id: getCurrentUser().uid,
+          create_time: serverTimestamp(),
           ...context,
         });
         toast.success(toastSuccessText);


### PR DESCRIPTION
Stacked PRs:
 * __->__#103


--- --- ---

# Add "create time" Timestamp

## :recycle: Current situation & Problem
Currently, we cannot use Firebase Query to get feedback within a certain time span. While this could still be handled in memory it is more efficient to have a `create time` timestamp that can be queried.

## :books: Documentation
* Add create time server timestamps
* Adjust python unit and integration tests
* Adjust Firestore security rules and change tests accordingly

## :white_check_mark: Testing
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/866aab53-152b-48ad-abff-8a763a36a2b1" />

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).