### PR TITLE
Add "create time" Firestore Test

### DIFF
--- a/firebase/firebase_rule_tests/firestore.test.ts
+++ b/firebase/firebase_rule_tests/firestore.test.ts
@@ -369,6 +369,17 @@ describe("Authenticated User Issue Access", () => {
       })
     );
   });
+  test("Test Block Incorrect Create Time", async () => {
+    const pastDate = new Date();
+    pastDate.setHours(pastDate.getHours() - 1);
+    await assertFails(
+      addDoc(collection(user1, "user_reported_issues"), {
+        ...issueContent,
+        user_id: "user1",
+        create_time: pastDate,
+      })
+    );
+  });
   test("Test Block Read Access", async () => {
     await assertFails(getDoc(doc(user1, "user_reported_issues/test")));
     await assertFails(getDoc(doc(user1, "user_reported_issues/test")));


### PR DESCRIPTION
Stacked PRs:
 * #107
 * __->__#106


--- --- ---

# Add "create time" Firestore Test

## :recycle: Current situation & Problem
An important test has been missing from the Firebase security rule tests for checking the create_time field


## :books: Documentation
* Adding a test for invalid Firestore create_date


## :white_check_mark: Testing
CI

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).