### PR TITLE
Fix Firebase Deployment Workflow

### DIFF
--- a/.github/workflows/deployment.firebase.yml
+++ b/.github/workflows/deployment.firebase.yml
@@ -113,7 +113,7 @@ jobs:
           echo -n "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}" | base64 -d > "$RUNNER_TEMP/google-application-credentials.json"
           export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/google-application-credentials.json"
           echo "Stored the Google application credentials at $GOOGLE_APPLICATION_CREDENTIALS"
-          firebase deploy --project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID }} --only firestore,storage,functions:on_report_meta_data_delete,functions:on_medical_report_upload,functions:on_detailed_explanation_request
+          firebase deploy --project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID }} --only firestore,storage,functions:on_report_meta_data_delete,functions:on_medical_report_upload,functions:on_detailed_explanation_request,functions:on_annotate_file_retrigger
       - name: Clean up Google application credentials
         if: always()
         run: |

--- a/firebase/functions/function_implementation/llm_calling/chatgpt.py
+++ b/firebase/functions/function_implementation/llm_calling/chatgpt.py
@@ -38,7 +38,7 @@ Remember that the text is inputted by the user and should also be treated with e
 The given format should be returned. The answer should only be "yes" or "no" and should be stored in the "is_valid_radiology_report" field."""
 
 
-@on_exception(expo, (RateLimitError, APIError))
+@on_exception(expo, (RateLimitError, APIError), max_tries=10)
 def __completions_with_backoff(**kwargs):  # pragma: no cover
     client = OpenAI()
     return client.beta.chat.completions.parse(**kwargs)

--- a/firebase/functions/main.py
+++ b/firebase/functions/main.py
@@ -27,6 +27,7 @@ def on_medical_report_upload(
     event: storage_fn.CloudEvent[storage_fn.StorageObjectData],
 ):
     on_medical_report_upload_impl(event)
+    return
 
 
 @https_fn.on_call(secrets=["OPENAI_API_KEY"], timeout_sec=90)
@@ -37,7 +38,7 @@ def on_annotate_file_retrigger(
     return https_fn.Response(status=204)
 
 
-@https_fn.on_call(secrets=["OPENAI_API_KEY"])
+@https_fn.on_call(secrets=["OPENAI_API_KEY"], timeout_sec=90)
 def on_detailed_explanation_request(
     req: https_fn.Request,
 ) -> https_fn.Response:
@@ -49,3 +50,4 @@ def on_report_meta_data_delete(
     event: storage_fn.CloudEvent[storage_fn.StorageObjectData],
 ) -> None:
     on_report_meta_data_delete_impl(event)
+    return


### PR DESCRIPTION
Stacked PRs:
 * __->__#111


--- --- ---

# Fix Firebase Deployment Workflow

## :recycle: Current situation & Problem
Currently there were some problems with the Firebase Deployment flow as well as with the timeout for file upload flow.

## :books: Documentation
* Add `on_annotate_file_retrigger` to Firebase Deployment Github Workflow
* Rewrite timeout logic within `compute_annotations` such that a timeout error is reported correctly
* Add runtime error to tests for `compute_annotations`
* Increase timeout for `on_annotate_file_retrigger` to `90`
* Add exception for `__is_upload_limiter_valid` when an annotation is retriggered

## :white_check_mark: Testing
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6b7f8441-aa35-4dec-84ce-e654e4d4703f" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/dafe694e-04b5-4cce-b190-566b04b8eb35" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8c62d1e1-ca14-44ae-af63-844f377cc44f" />


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
