### PR TITLE
Enhance Firebase Storage Security Rules and Enhance Testing

### DIFF
--- a/firebase/firebase_rule_tests/firestore.test.ts
+++ b/firebase/firebase_rule_tests/firestore.test.ts
@@ -286,18 +286,20 @@ describe("Unauthenticated User Issue Access", () => {
   let existingDocRef;
   beforeAll(async () => {
     unauthenticatedUser = db.unauthenticatedContext().firestore();
-    existingDocRef = doc(unauthenticatedUser, "user_reported_issue/newDoc");
+    existingDocRef = doc(unauthenticatedUser, "users_reported_issues/newDoc");
     const issueContent = { test: "test" };
 
     db.withSecurityRulesDisabled(async (context) => {
-      await setDoc(doc(context.firestore(), "user_reported_issue/newDoc"), {
+      await setDoc(doc(context.firestore(), "users_reported_issues/newDoc"), {
         ...issueContent,
         create_time: serverTimestamp(),
       });
     });
     return async () => {
       await db.withSecurityRulesDisabled(async (context) => {
-        await deleteDoc(doc(context.firestore(), "user_reported_issue/newDoc"));
+        await deleteDoc(
+          doc(context.firestore(), "users_reported_issues/newDoc")
+        );
       });
     };
   });
@@ -306,7 +308,7 @@ describe("Unauthenticated User Issue Access", () => {
   });
   test("Blocking New File List Access", async () => {
     await assertFails(
-      getDocs(collection(unauthenticatedUser, "user_reported_issues"))
+      getDocs(collection(unauthenticatedUser, "users_reported_issues"))
     );
   });
   test("Blocking New File Write Access", async () => {
@@ -373,7 +375,7 @@ describe("Authenticated User Issue Access", () => {
     const pastDate = new Date();
     pastDate.setHours(pastDate.getHours() - 1);
     await assertFails(
-      addDoc(collection(user1, "user_reported_issues"), {
+      addDoc(collection(user1, "users_reported_issues"), {
         ...issueContent,
         user_id: "user1",
         create_time: pastDate,
@@ -381,8 +383,8 @@ describe("Authenticated User Issue Access", () => {
     );
   });
   test("Test Block Read Access", async () => {
-    await assertFails(getDoc(doc(user1, "user_reported_issues/test")));
-    await assertFails(getDoc(doc(user1, "user_reported_issues/test")));
+    await assertFails(getDoc(doc(user1, "users_reported_issues/test")));
+    await assertFails(getDoc(doc(user2, "users_reported_issues/test")));
   });
   test("Test Block List Access", async () => {
     await assertFails(getDocs(collection(user1, "users_reported_issues")));
@@ -390,21 +392,21 @@ describe("Authenticated User Issue Access", () => {
   });
   test("Test Block Update Access", async () => {
     await assertFails(
-      updateDoc(doc(user1, "user_reported_issues/test"), {
+      updateDoc(doc(user1, "users_reported_issues/test"), {
         ...issueContent,
         user_id: "user1",
       })
     );
     await assertFails(
-      updateDoc(doc(user1, "user_reported_issues/test"), {
+      updateDoc(doc(user1, "users_reported_issues/test"), {
         ...issueContent,
         user_id: "user2",
       })
     );
   });
   test("Test Block Delete Access", async () => {
-    await assertFails(deleteDoc(doc(user1, "user_reported_issues/test")));
-    await assertFails(deleteDoc(doc(user1, "user_reported_issues/test")));
+    await assertFails(deleteDoc(doc(user1, "users_reported_issues/test")));
+    await assertFails(deleteDoc(doc(user1, "users_reported_issues/test")));
   });
 });
 
@@ -413,18 +415,20 @@ describe("Unauthenticated User Positive Feedback Access", () => {
   let existingDocRef;
   beforeAll(async () => {
     unauthenticatedUser = db.unauthenticatedContext().firestore();
-    existingDocRef = doc(unauthenticatedUser, "user_reported_issue/newDoc");
+    existingDocRef = doc(unauthenticatedUser, "users_positive_feedback/newDoc");
     const issueContent = { test: "test" };
 
     db.withSecurityRulesDisabled(async (context) => {
       await setDoc(
-        doc(context.firestore(), "user_reported_issue/newDoc"),
+        doc(context.firestore(), "users_positive_feedback/newDoc"),
         issueContent
       );
     });
     return async () => {
       await db.withSecurityRulesDisabled(async (context) => {
-        await deleteDoc(doc(context.firestore(), "user_reported_issue/newDoc"));
+        await deleteDoc(
+          doc(context.firestore(), "users_positive_feedback/newDoc")
+        );
       });
     };
   });
@@ -511,7 +515,7 @@ describe("Authenticated User Positive Feedback Access", () => {
   });
   test("Test Block Read Access", async () => {
     await assertFails(getDoc(doc(user1, "users_positive_feedback/test")));
-    await assertFails(getDoc(doc(user1, "users_positive_feedback/test")));
+    await assertFails(getDoc(doc(user2, "users_positive_feedback/test")));
   });
   test("Test Block List Access", async () => {
     await assertFails(getDocs(collection(user1, "users_positive_feedback")));
@@ -533,6 +537,6 @@ describe("Authenticated User Positive Feedback Access", () => {
   });
   test("Test Block Delete Access", async () => {
     await assertFails(deleteDoc(doc(user1, "users_positive_feedback/test")));
-    await assertFails(deleteDoc(doc(user1, "users_positive_feedback/test")));
+    await assertFails(deleteDoc(doc(user2, "users_positive_feedback/test")));
   });
 });

--- a/firebase/firebase_rule_tests/storage.test.ts
+++ b/firebase/firebase_rule_tests/storage.test.ts
@@ -1,4 +1,3 @@
-
 //
 // This source file is part of the Stanford Biodesign Digital Health RadGPT open-source project
 //
@@ -7,94 +6,132 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { beforeAll, describe, test } from 'vitest'
+import crypto from "crypto";
+import { beforeAll, describe, test } from "vitest";
 import {
-    assertFails,
-    assertSucceeds,
-    initializeTestEnvironment
-} from '@firebase/rules-unit-testing'
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from "@firebase/rules-unit-testing";
 import {
-    deleteObject,
-    getBytes,
-    listAll,
-    ref,
-    uploadString,
+  deleteObject,
+  getBytes,
+  listAll,
+  ref,
+  uploadString,
 } from "firebase/storage";
 
-const PROJECT_ID = "demo-radgpt"
+const PROJECT_ID = "demo-radgpt";
 
-const db = await initializeTestEnvironment({ projectId: PROJECT_ID })
+const db = await initializeTestEnvironment({ projectId: PROJECT_ID });
 
 describe("Unauthenticated", () => {
-    let testRef;
-    beforeAll(async () => {
-        const unauthenticatedDb = db.unauthenticatedContext().storage();
-        testRef = ref(unauthenticatedDb, "/users/user1/reports/document")
-    })
-    test("Blocking Read/List Access", async () => {
-        await assertFails(getBytes(testRef))
-    })
-    test("Blocking Write Access", async () => {
-        await assertFails(uploadString(testRef, ""))
-    })
-})
+  let testRef;
+  beforeAll(async () => {
+    const unauthenticatedDb = db.unauthenticatedContext().storage();
+    testRef = ref(unauthenticatedDb, "/users/user1/reports/document");
+  });
+  test("Blocking Read/List Access", async () => {
+    await assertFails(getBytes(testRef));
+  });
+  test("Blocking Write Access", async () => {
+    await assertFails(uploadString(testRef, ""));
+  });
+});
 
 describe("Authenticated Processed Annotations Access", () => {
-    let user1;
-    let user2;
-    beforeAll(async () => {
-        user1 = db.authenticatedContext("user1").storage();
-        user2 = db.authenticatedContext("user2").storage();
-        await uploadString(ref(user1, "/users/user1/reports/document"), "test", "raw", {
-            contentType: "text/plain",
-        })
+  let user1;
+  let user2;
+  const uuid = crypto.randomUUID();
+  beforeAll(async () => {
+    user1 = db.authenticatedContext("user1").storage();
+    user2 = db.authenticatedContext("user2").storage();
+    await uploadString(
+      ref(user1, `/users/user1/reports/${uuid}`),
+      "test",
+      "raw",
+      {
+        contentType: "text/plain",
+      }
+    );
 
-        return async () => {
-            await db.withSecurityRulesDisabled(async (context) => {
-                await deleteObject(ref(context.storage(), "/users/user1/reports/document"))
-            })
+    return async () => {
+      await db.withSecurityRulesDisabled(async (context) => {
+        await deleteObject(
+          ref(context.storage(), `/users/user1/reports/${uuid}`)
+        );
+      });
+    };
+  });
+  test("Test Allowed User1 Read Access", async () => {
+    const documentRef = ref(user1, `/users/user1/reports/${uuid}`);
+    const folderRef = ref(user1, "/users/user1/reports");
+    await assertSucceeds(getBytes(documentRef));
+    await assertSucceeds(listAll(folderRef));
+  });
+  test("Test Blocked User2 Read Access", async () => {
+    const documentRef = ref(user2, `/users/user1/reports/${uuid}`);
+    const folderRef = ref(user2, "/users/user1/reports");
+    await assertFails(getBytes(documentRef));
+    await assertFails(listAll(folderRef));
+  });
+  test("Test Allowed File Upload User 1", async () => {
+    await assertFails(
+      uploadString(ref(user1, `/users/user1/reports/${uuid}`), "test1", "raw", {
+        contentType: "text/plain",
+      })
+    );
+    await assertSucceeds(
+      uploadString(
+        ref(user1, `/users/user1/reports/${crypto.randomUUID()}`),
+        "test1",
+        "raw",
+        {
+          contentType: "text/plain",
         }
-    })
-    test("Test Allowed User1 Read Access", async () => {
-        const documentRef = ref(user1, "/users/user1/reports/document")
-        const folderRef = ref(user1, "/users/user1/reports")
-        await assertSucceeds(getBytes(documentRef))
-        await assertSucceeds(listAll(folderRef))
-    })
-    test("Test Blocked User2 Read Access", async () => {
-        const documentRef = ref(user2, "/users/user1/reports/document")
-        const folderRef = ref(user2, "/users/user1/reports")
-        await assertFails(getBytes(documentRef))
-        await assertFails(listAll(folderRef))
-    })
-    test("Test Allowed File Upload User 1", async() => {
-        await assertSucceeds(uploadString(ref(user1, "/users/user1/reports/document1"), "test1", "raw", {
-            contentType: "text/plain",
-        }))
-    })
-    test("Test Blocked Overwrite through File Upload User 1", async() => {
-        await assertFails(uploadString(ref(user1, "/users/user1/reports/document"), "test1", "raw", {
-            contentType: "text/plain",
-        }))
-    })
-    test("Test Allowed File Upload User 2", async() => {
-        await assertFails(uploadString(ref(user2, "/users/user1/reports/document2"), "test1", "raw", {
-            contentType: "text/plain",
-        }))
-    })
-})
+      )
+    );
+  });
+  test("Test Blocked Overwrite through File Upload User 1", async () => {
+    await assertFails(
+      uploadString(ref(user1, `/users/user1/reports/${uuid}`), "test1", "raw", {
+        contentType: "text/plain",
+      })
+    );
+  });
+  test("Test Allowed File Upload User 2", async () => {
+    await assertFails(
+      uploadString(
+        ref(user2, `/users/user1/reports/${crypto.randomUUID()}`),
+        "test1",
+        "raw",
+        {
+          contentType: "text/plain",
+        }
+      )
+    );
+  });
+});
 
 describe("Authenticated Processed Annotations Deletion", () => {
-    let user1;
-    let user2;
+  let user1;
+  let user2;
 
-    test("Test Blocked File Deletion", async () => {
-        user1 = db.authenticatedContext("user1").storage();
-        user2 = db.authenticatedContext("user2").storage();
-        await uploadString(ref(user1, "/users/user1/reports/document"), "test", "raw", {
-            contentType: "text/plain",
-        })
-        await assertSucceeds(deleteObject(ref(user1, "/users/user1/reports/document")))
-        await assertFails(deleteObject(ref(user2, "/users/user1/reports/document")))
-    })
-})
+  test("Test Blocked File Deletion", async () => {
+    user1 = db.authenticatedContext("user1").storage();
+    user2 = db.authenticatedContext("user2").storage();
+    const uuid = crypto.randomUUID();
+    await uploadString(
+      ref(user1, `/users/user1/reports/${uuid}`),
+      "test",
+      "raw",
+      {
+        contentType: "text/plain",
+      }
+    );
+    await assertFails(deleteObject(ref(user2, `/users/user1/reports/${uuid}`)));
+    await assertSucceeds(
+      deleteObject(ref(user1, `/users/user1/reports/${uuid}`))
+    );
+  });
+});

--- a/firebase/package-lock.json
+++ b/firebase/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@firebase/rules-unit-testing": "^4.0.1",
+        "crypto": "^1.0.1",
         "firebase": "^11.1.0",
         "vitest": "^3.0.9"
       }
@@ -2462,6 +2463,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -13,6 +13,7 @@
   "description": "",
   "devDependencies": {
     "@firebase/rules-unit-testing": "^4.0.1",
+    "crypto": "^1.0.1",
     "firebase": "^11.1.0",
     "vitest": "^3.0.9"
   }

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -14,11 +14,18 @@ service firebase.storage {
       return request.auth != null && request.auth.uid == userId;
     }
 
+    function isUUID(fileName) {
+      return fileName.matches(
+        '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      );
+    }
+
     match /users/{userId}/reports/{reportUUID} {
       allow read: if isAuthenticatedUserID(userId);
       allow create: if isAuthenticatedUserID(userId)
                     && request.resource.contentType.matches("text/plain")
-                    && resource == null;
+                    && resource == null
+                    && isUUID(reportUUID);
       allow delete: if isAuthenticatedUserID(userId);
     } 
   }


### PR DESCRIPTION
Stacked PRs:
 * #114
 * __->__#115


--- --- ---

# Enhance Firebase Storage Security Rules and Enhance Testing

## :recycle: Current situation & Problem
We allowed any filename for the Firestore Cloud Storage file uploaded by the user and we had some bugs in the Security Rule Tests.

## :books: Documentation
* Restrict filename to UUID format
* Enhance Firebase Security Rule Tests

## :white_check_mark: Testing


CI


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).